### PR TITLE
Adds cli to pull in data silos from app.transcend.io to .yaml file

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -37,6 +37,7 @@
     "source.fixAll": true
   },
   "cSpell.words": [
+    "Blocklist",
     "camelcase",
     "codomain",
     "compat",

--- a/README.md
+++ b/README.md
@@ -6,80 +6,204 @@
 - [Overview](#overview)
 - [Installation](#installation)
 - [Authentication](#authentication)
+- [transcend.yml](#transcendyml)
 - [Usage](#usage)
-  - [transcend:pull](#transcendpull)
-  - [transcend:push](#transcendpush)
-- [Local Development](#local-development)
-  - [Typescript Build](#typescript-build)
-  - [Lint](#lint)
+  - [tr-pull](#tr-pull)
+  - [tr-push](#tr-push)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Overview
 
-A command line interface for programmatically creating data silos on app.transcend.io
+A command line interface that allows you to define your Data Map in code and sync that configuration back to https://app.transcend.io.
 
 ## Installation
 
-This package is distributed through npm and github package registries. The simplest way to install would be:
+This package is distributed through npm and github package registries and assumes an installation of [npm and node](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm).
+
+If your codebase is typescript or javascript based, you can add this package as a dev dependency:
 
 ```sh
+# install locally with yarn
 yarn add -D @transcend-io/schema-sync
+
+# cli commands available within package
+yarn tr-pull --auth=xxx
+yarn tr-push --auth=xxx
 ```
 
 or
 
 ```sh
+# install locally with npm
 npm i -D @transcend-io/schema-sync
+
+# cli commands available within package
+tr-pull --auth=xxx
+tr-push --auth=xxx
+```
+
+alternatively, you can install the cli globally on your machine:
+
+```sh
+# install locally with npm
+npm i -g @transcend-io/schema-sync
+
+# cli commands available everywhere on machine
+tr-pull --auth=xxx
+tr-push --auth=xxx
 ```
 
 ## Authentication
 
-In order to use this cli, you will first need to generate an API key on the Transcend admin dashboard (https://app.transcend.io/infrastructure/api-keys).
+In order to use this cli, you will first need to generate an API key on the Transcend Admin Dashboard (https://app.transcend.io/infrastructure/api-keys).
 
 The API key needs the following scopes:
 
 - Manage Data Map
 - Manage Request Identity Verification
-- Connect Data Silos
+- Connect data silos
 - Manage Data Subject Request Settings
 - View API Keys
 
+## transcend.yml
+
+Within your git repositories, you can define a file `transcend.yml`. This file allows you define part of your Data Map in code. Using the cli, you can sync that configuration back to the Transcend Admin Dashboard (https://app.transcend.io/privacy-requests/connected-services).
+
+You can find various examples for your `transcend.yml` file in the [examples/](./examples/) folder. If you are looking for a starting point to copy and paste, [simple.yml](./examples/simple.yml) is a good place to start. This file is annotated with links and documentations that new members of your team can use if they come across the file.
+
+The API for this YAML file can be found in [./src/codecs.ts](./src/codecs.ts) under the variable named "TranscendInput". The shape of the yaml file will be type-checked every time a command is run.
+
+The structure of the file looks something like the following:
+
+```yaml
+# Manage at: https://app.transcend.io/infrastructure/api-keys
+# See https://docs.transcend.io/docs/authentication
+# Define API keys that may be shared across data silos
+# in the data map. When creating new data silos through the yaml
+# cli, it is possible to specify which API key should be associated
+# with the newly created data silo.
+api-keys:
+  - title: Webhook Key
+  - title: Analytics Key
+
+# Manage at: https://app.transcend.io/privacy-requests/identifiers
+# See https://docs.transcend.io/docs/identity-enrichment
+# Define enricher or pre-flight check webhooks that will be executed
+# prior to privacy request workflows. Some examples may include:
+#   - identity enrichment: look up additional identifiers for that user.
+#                          i.e. map an email address to a user ID
+#   - fraud check: auto-cancel requests if the user is flagged for fraudulent behavior
+#   - customer check: auto-cancel request for some custom business criteria
+enrichers:
+  - title: Basic Identity Enrichment
+    description: Enrich an email address to the userId and phone number
+    url: https://example.acme.com/transcend-enrichment-webhook
+    input-identifier: email
+    output-identifiers:
+      - userId
+      - phone
+      - myUniqueIdentifier
+  - title: Fraud Check
+    description: Ensure the email address is not marked as fraudulent
+    url: https://example.acme.com/transcend-fraud-check
+    input-identifier: email
+    output-identifiers:
+      - email
+    privacy-actions:
+      - ERASURE
+
+# Manage at: https://app.transcend.io/privacy-requests/connected-services
+# See https://docs.transcend.io/docs/the-data-map#data-silos
+# Define the data silos in your data map. A data silo can be a database,
+# or a web service that may use a collection of different data stores under the hood.
+data-silos:
+  # Note: title is the only required top-level field for a data silo
+  - title: Redshift Data Warehouse
+    description: The mega-warehouse that contains a copy over all SQL backed databases
+    url: https://example.acme.com/transcend-webhook
+    api-key-title: Webhook Key
+    privacy-actions:
+      - ACCESS
+      - ERASURE
+      - SALE_OPT_OUT
+    data-subjects:
+      - customer
+      - employee
+      - newsletter-subscriber
+      - b2b-contact
+    identity-keys:
+      - email
+      - userId
+    deletion-dependencies:
+      - Identity Service
+    owners:
+      - alice@transcend.io
+    objects:
+      - title: User Model
+        description: The centralized user model user
+        key: users
+        purpose: ESSENTIAL
+        category: USER_PROFILE
+        privacy-actions:
+          - ACCESS
+        fields:
+          - key: firstName
+            title: First Name
+            description: The first name of the user, inputted during onboarding
+          - key: email
+            title: Email
+            description: The email address of the user
+```
+
 ## Usage
 
-### transcend:pull
+### tr-pull
+
+Generate's a transcend.yml by pulling the configuration from your connected services view (https://app.transcend.io/privacy-requests/connected-services).
+
+This command can be helpful if you are looking to:
+
+- Copy parts of your Data Map from one Transcend instance into another instance
+- Generate a transcend.yml file as a starting point to maintain parts of your Data Map in code
 
 ```sh
-yarn transcend:pull --auth=<api-key>
+# Writes out file to ./transcend.yml
+tr-pull --auth=<api-key>
 ```
 
-### transcend:push
+An alternative file destination can be specified:
 
 ```sh
-yarn transcend:push --auth=<api-key>
+# Writes out file to ./custom/location.yml
+tr-pull --auth=<api-key> --file=./custom/location.yml
 ```
 
-## Local Development
+Note: This command will overwrite the existing transcend.yml file that you have locally.
 
-### Typescript Build
+### tr-push
 
-Build this package only:
+Given a transcend.yml file, sync the contents up to your connected services view (https://app.transcend.io/privacy-requests/connected-services).
 
 ```sh
-yarn run tsc
-yarn run tsc --watch # Watch mode
+# Looks for file at ./transcend.yml
+tr-push --auth=<api-key>
 ```
 
-Create a fresh build:
+An alternative file destination can be specified:
 
 ```sh
-yarn clean && yarn run tsc
+# Looks for file at custom location ./custom/location.yml
+tr-pull --auth=<api-key> --file=./custom/location.yml
 ```
 
-### Lint
+Some things to note about this sync process:
 
-Lint the typescript files in this package:
+1. Any field that is defined in your .yml file will be synced up to app.transcend.io. If any change was made on the admin dashboard, it will be overwritten.
+2. If you omit a field from the yaml file, this field will not be synced. This gives you the ability to define as much or as little configuration in your transcend.yml file as you would like, and let the remainder of fields be labeled through the Admin Dashboard
+3. If you define new data subjects, identifiers, data silos or objects that were not previously defined on the Admin Dashboard, the cli will create these new resources automatically.
+4. Currently, this cli does not handle deleting or renaming of resources. If you need to delete or rename a data silo, identifier, enricher or API key, you should make the change on the Admin Dashboard.
+5. The only resources that this cli will not auto generate are:
 
-```sh
-yarn lint
-```
+- a) Data silo owners: If you assign an email address to a data silo, you must first make sure that user is invited into your Transcend instance (https://app.transcend.io/admin/users).
+- b) API keys: This cli will not create new API keys. You will need to first create the new API keys on the Admin Dashboard (https://app.transcend.io/infrastructure/api-keys). You can then list out the titles of the API keys that you generated in your transcend.yml file, after which the cli is capable of updating that API key to be able to respond to different data silos in your Data Map

--- a/README.md
+++ b/README.md
@@ -4,8 +4,14 @@
 ## Table of Contents
 
 - [Overview](#overview)
-- [Typescript Build](#typescript-build)
-- [Lint](#lint)
+- [Installation](#installation)
+- [Authentication](#authentication)
+- [Usage](#usage)
+  - [transcend:pull](#transcendpull)
+  - [transcend:push](#transcendpush)
+- [Local Development](#local-development)
+  - [Typescript Build](#typescript-build)
+  - [Lint](#lint)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -13,7 +19,49 @@
 
 A command line interface for programmatically creating data silos on app.transcend.io
 
-## Typescript Build
+## Installation
+
+This package is distributed through npm and github package registries. The simplest way to install would be:
+
+```sh
+yarn add -D @transcend-io/schema-sync
+```
+
+or
+
+```sh
+npm i -D @transcend-io/schema-sync
+```
+
+## Authentication
+
+In order to use this cli, you will first need to generate an API key on the Transcend admin dashboard (https://app.transcend.io/infrastructure/api-keys).
+
+The API key needs the following scopes:
+
+- Manage Data Map
+- Manage Request Identity Verification
+- Connect Data Silos
+- Manage Data Subject Request Settings
+- View API Keys
+
+## Usage
+
+### transcend:pull
+
+```sh
+yarn transcend:pull --auth=<api-key>
+```
+
+### transcend:push
+
+```sh
+yarn transcend:push --auth=<api-key>
+```
+
+## Local Development
+
+### Typescript Build
 
 Build this package only:
 
@@ -28,7 +76,7 @@ Create a fresh build:
 yarn clean && yarn run tsc
 ```
 
-## Lint
+### Lint
 
 Lint the typescript files in this package:
 

--- a/examples/generated.yml
+++ b/examples/generated.yml
@@ -1,0 +1,28 @@
+api-keys:
+  - title: Transcend Prod Server Silo Key
+enrichers: []
+data-silos:
+  - title: Customer.io
+    description: >-
+      Customer.io is a behavioral messaging platform for triggering personalized
+      and event-based customer communication.
+    identity-keys:
+      - coreIdentifier
+      - email
+      - segmentId
+    deletion-dependencies: []
+    owners: []
+    disabled: true
+    privacy-actions:
+      - ERASURE
+    objects: []
+  - title: Facebook Ads
+    description: Targeted ad campaigns on Facebook for businesses.
+    identity-keys:
+      - email
+    deletion-dependencies: []
+    owners: []
+    disabled: false
+    privacy-actions:
+      - ERASURE
+    objects: []

--- a/examples/multi-instance.yml
+++ b/examples/multi-instance.yml
@@ -1,0 +1,26 @@
+api-keys:
+  - title: Webhook Key
+enrichers:
+  - title: Basic Identity Enrichment
+    description: Enrich an email address to the userId and phone number
+    # The data silo webhook URL is the same in each environment,
+    # except for the base domain in the webhook URL.
+    url: https://example.<<parameters.domain>>/transcend-enrichment-webhook
+    input-identifier: email
+    output-identifiers:
+      - userId
+      - phone
+      - myUniqueIdentifier
+  - title: Fraud Check
+    description: Ensure the email address is not marked as fraudulent
+    url: https://example.<<parameters.domain>>/transcend-fraud-check
+    input-identifier: email
+    output-identifiers:
+      - email
+    privacy-actions:
+      - ERASURE
+data-silos:
+  - title: Redshift Data Warehouse
+    description: The mega-warehouse that contains a copy over all SQL backed databases
+    url: https://example.<<parameters.domain>>/transcend-webhook
+    api-key-title: Webhook Key

--- a/examples/multi-instance.yml
+++ b/examples/multi-instance.yml
@@ -21,6 +21,6 @@ enrichers:
       - ERASURE
 data-silos:
   - title: Redshift Data Warehouse
-    description: The mega-warehouse that contains a copy over all SQL backed databases
+    description: The mega-warehouse that contains a copy over all SQL backed databases - <<parameters.stage>>
     url: https://example.<<parameters.domain>>/transcend-webhook
     api-key-title: Webhook Key

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/schema-sync",
   "description": "Small package containing useful typescript utilities.",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "homepage": "https://github.com/transcend-io/schema-sync",
   "repository": {
     "type": "git",
@@ -10,6 +10,10 @@
   },
   "license": "MIT",
   "main": "build/index",
+  "bin": {
+    "transcend:pull": "build/cli-pull",
+    "transcend:push": "build/cli-push"
+  },
   "files": [
     "build/**/*",
     "package.json"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/schema-sync",
   "description": "Small package containing useful typescript utilities.",
-  "version": "1.2.0",
+  "version": "1.4.5",
   "homepage": "https://github.com/transcend-io/schema-sync",
   "repository": {
     "type": "git",
@@ -11,8 +11,8 @@
   "license": "MIT",
   "main": "build/index",
   "bin": {
-    "transcend:pull": "build/cli-pull",
-    "transcend:push": "build/cli-push"
+    "tr-pull": "./build/cli-pull.js",
+    "tr-push": "./build/cli-push.js"
   },
   "files": [
     "build/**/*",

--- a/src/cli-pull.ts
+++ b/src/cli-pull.ts
@@ -1,4 +1,4 @@
-#!/user/bin/env node
+#!/usr/bin/env node
 
 import yargs from 'yargs-parser';
 import { logger } from './logger';
@@ -15,7 +15,7 @@ import { ADMIN_DASH } from './constants';
  * yarn ts-node ./src/cli-pull.ts --file=./examples/invalid.yml --auth=asd123
  *
  * Standard usage
- * yarn transcend:push --file=./examples/invalid.yml --auth=asd123
+ * yarn tr-push --file=./examples/invalid.yml --auth=asd123
  */
 async function main(): Promise<void> {
   // Parse command line arguments
@@ -45,7 +45,7 @@ async function main(): Promise<void> {
     },
   });
 
-  // Sync to Transcend
+  // Sync to Disk
   try {
     const configuration = await pullTranscendConfiguration(client);
     writeTranscendYaml(file, configuration);

--- a/src/cli-pull.ts
+++ b/src/cli-pull.ts
@@ -1,0 +1,67 @@
+#!/user/bin/env node
+
+import yargs from 'yargs-parser';
+import { logger } from './logger';
+import colors from 'colors';
+import { pullTranscendConfiguration } from './pullTranscendConfiguration';
+import { GraphQLClient } from 'graphql-request';
+import { writeTranscendYaml } from './readTranscendYaml';
+import { ADMIN_DASH } from './constants';
+
+/**
+ * Sync data silo configuration from Transcend down locally to disk
+ *
+ * Dev Usage:
+ * yarn ts-node ./src/cli-pull.ts --file=./examples/invalid.yml --auth=asd123
+ *
+ * Standard usage
+ * yarn transcend:push --file=./examples/invalid.yml --auth=asd123
+ */
+async function main(): Promise<void> {
+  // Parse command line arguments
+  const {
+    file = './transcend.yml',
+    transcendUrl = 'https://api.transcend.io',
+    auth,
+  } = yargs(process.argv.slice(2));
+
+  // Ensure auth is passed
+  if (!auth) {
+    logger.error(
+      colors.red(
+        'A Transcend API key must be provided. You can specify using --auth=asd123',
+      ),
+    );
+    process.exit(1);
+  }
+
+  // Create a GraphQL client
+  // eslint-disable-next-line global-require
+  const { version } = require('../package.json');
+  const client = new GraphQLClient(`${transcendUrl}/graphql`, {
+    headers: {
+      Authorization: `Bearer ${auth}`,
+      version,
+    },
+  });
+
+  // Sync to Transcend
+  try {
+    const configuration = await pullTranscendConfiguration(client);
+    writeTranscendYaml(file, configuration);
+  } catch (err) {
+    logger.error(
+      colors.red(`An error occurred syncing the schema: ${err.message}`),
+    );
+    process.exit(1);
+  }
+
+  // Indicate success
+  logger.info(
+    colors.green(
+      `Successfully synced yaml file to disk at ${file}! View at ${ADMIN_DASH}`,
+    ),
+  );
+}
+
+main();

--- a/src/cli-push.ts
+++ b/src/cli-push.ts
@@ -1,3 +1,5 @@
+#!/user/bin/env node
+
 import yargs from 'yargs-parser';
 import { logger } from './logger';
 import { existsSync } from 'fs';
@@ -7,28 +9,29 @@ import { TranscendInput } from './codecs';
 import { syncConfigurationToTranscend } from './syncConfigurationToTranscend';
 import { GraphQLClient } from 'graphql-request';
 
-const ADMIN_DASH =
-  'https://app.transcend.io/privacy-requests/connected-services';
-
+import { ADMIN_DASH } from './constants';
 /**
- * Main cli
+ * Push the transcend.yml file remotely into a Transcend instance
  *
- * Usage:
- * yarn ts-node ./build/main.js --file=./examples/invalid.yml --authorization=asd123
+ * Dev Usage:
+ * yarn ts-node ./src/cli-push.ts --file=./examples/invalid.yml --auth=asd123
+ *
+ * Standard usage
+ * yarn transcend:push --file=./examples/invalid.yml --auth=asd123
  */
 async function main(): Promise<void> {
   // Parse command line arguments
   const {
     file = './transcend.yml',
     transcendUrl = 'https://api.transcend.io',
-    authorization,
+    auth,
   } = yargs(process.argv.slice(2));
 
-  // Ensure authorization is passed
-  if (!authorization) {
+  // Ensure auth is passed
+  if (!auth) {
     logger.error(
       colors.red(
-        'A Transcend API key must be provided. You can specify using --authorization=asd123',
+        'A Transcend API key must be provided. You can specify using --auth=asd123',
       ),
     );
     process.exit(1);
@@ -65,7 +68,7 @@ async function main(): Promise<void> {
   const { version } = require('../package.json');
   const client = new GraphQLClient(`${transcendUrl}/graphql`, {
     headers: {
-      Authorization: `Bearer ${authorization}`,
+      Authorization: `Bearer ${auth}`,
       version,
     },
   });

--- a/src/cli-push.ts
+++ b/src/cli-push.ts
@@ -1,4 +1,4 @@
-#!/user/bin/env node
+#!/usr/bin/env node
 
 import yargs from 'yargs-parser';
 import { logger } from './logger';
@@ -17,7 +17,7 @@ import { ADMIN_DASH } from './constants';
  * yarn ts-node ./src/cli-push.ts --file=./examples/invalid.yml --auth=asd123
  *
  * Standard usage
- * yarn transcend:push --file=./examples/invalid.yml --auth=asd123
+ * yarn tr-push --file=./examples/invalid.yml --auth=asd123
  */
 async function main(): Promise<void> {
   // Parse command line arguments

--- a/src/codecs.ts
+++ b/src/codecs.ts
@@ -2,8 +2,8 @@ import * as t from 'io-ts';
 import { valuesOf } from '@transcend-io/type-utils';
 import {
   DataCategoryType,
-  InternalDataSiloObjectResolver,
   ProcessingPurpose,
+  RequestAction,
   RequestActionObjectResolver,
 } from '@transcend-io/privacy-types';
 
@@ -57,7 +57,7 @@ export const EnricherInput = t.intersection([
     /** Internal description for why the enricher is needed */
     description: t.string,
     /** The privacy actions that the enricher should run against */
-    'privacy-actions': t.array(t.string),
+    'privacy-actions': t.array(valuesOf(RequestAction)),
   }),
 ]);
 
@@ -120,7 +120,7 @@ export const ObjectInput = t.intersection([
      *
      * @see https://github.com/transcend-io/privacy-types/blob/main/src/actions.ts
      */
-    'privacy-actions': t.array(valuesOf(InternalDataSiloObjectResolver)),
+    'privacy-actions': t.array(valuesOf(RequestActionObjectResolver)),
     /**
      * Provide field-level metadata for this object.
      * This is often the column metadata

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,2 @@
+export const ADMIN_DASH =
+  'https://app.transcend.io/privacy-requests/connected-services';

--- a/src/fetchApiKeys.ts
+++ b/src/fetchApiKeys.ts
@@ -24,6 +24,7 @@ const ADMIN_LINK = 'https://app.transcend.io/infrastructure/api-keys';
  *
  * @param apiKeyInputs - API keys to fetch metadata on
  * @param client - GraphQL client
+ * @param fetchAll - When true, fetch all API keys
  * @returns A map from apiKey title to Identifier
  */
 export async function fetchApiKeys(
@@ -32,8 +33,13 @@ export async function fetchApiKeys(
     'data-silos': dataSilos = [],
   }: TranscendInput,
   client: GraphQLClient,
+  fetchAll = false,
 ): Promise<{ [k in string]: ApiKey }> {
-  logger.info(colors.magenta(`Fetching ${apiKeyInputs.length} API keys...`));
+  logger.info(
+    colors.magenta(
+      `Fetching ${fetchAll ? 'all' : apiKeyInputs.length} API keys...`,
+    ),
+  );
   const titles = apiKeyInputs.map(({ title }) => title);
   const apiKeys: ApiKey[] = [];
   let offset = 0;
@@ -47,7 +53,7 @@ export async function fetchApiKeys(
     } = await client.request(API_KEYS, {
       first: PAGE_SIZE,
       offset,
-      titles,
+      titles: fetchAll ? undefined : titles,
     });
     apiKeys.push(...nodes);
     offset += PAGE_SIZE;

--- a/src/gqls.ts
+++ b/src/gqls.ts
@@ -1,17 +1,20 @@
 import { gql } from 'graphql-request';
 
 export const ENRICHERS = gql`
-  query SchemaSyncEnrichers($title: String!) {
-    enrichers(filterBy: { text: $title }) {
+  query SchemaSyncEnrichers($title: String, $first: Int!, $offset: Int!) {
+    enrichers(filterBy: { text: $title }, first: $first, offset: $offset) {
       nodes {
         id
         title
+        url
+        type
         inputIdentifier {
           name
         }
         identifiers {
           name
         }
+        actions
       }
     }
   }
@@ -29,7 +32,7 @@ export const IDENTIFIERS = gql`
 `;
 
 export const API_KEYS = gql`
-  query SchemaSyncApiKeys($first: Int!, $offset: Int!, $titles: [String!]!) {
+  query SchemaSyncApiKeys($first: Int!, $offset: Int!, $titles: [String!]) {
     apiKeys(first: $first, offset: $offset, filterBy: { titles: $titles }) {
       nodes {
         id
@@ -110,12 +113,59 @@ export const UPDATE_ENRICHER = gql`
 `;
 
 export const DATA_SILOS = gql`
-  query SchemaSyncDataSilos($title: String!) {
-    dataSilos(filterBy: { text: $title }) {
+  query SchemaSyncDataSilos($title: String, $first: Int!, $offset: Int!) {
+    dataSilos(filterBy: { text: $title }, first: $first, offset: $offset) {
       nodes {
         id
         title
       }
+    }
+  }
+`;
+
+export const DATA_SILO = gql`
+  query SchemaSyncDataSilo($id: String!) {
+    dataSilo(id: $id) {
+      id
+      title
+      description
+      url
+      apiKeys {
+        title
+      }
+      subjectBlocklist {
+        type
+      }
+      globalActions {
+        type
+        active
+      }
+      dataPoints {
+        id
+        title {
+          defaultMessage
+        }
+        description {
+          defaultMessage
+        }
+        name
+        purpose
+        category
+        actionSettings {
+          type
+          active
+        }
+      }
+      identifiers {
+        name
+      }
+      dependentDataSilos {
+        title
+      }
+      owners {
+        email
+      }
+      isLive
     }
   }
 `;

--- a/src/pullTranscendConfiguration.ts
+++ b/src/pullTranscendConfiguration.ts
@@ -1,0 +1,125 @@
+import {
+  TranscendInput,
+  ApiKeyInput,
+  DataSiloInput,
+  EnricherInput,
+} from './codecs';
+import { GraphQLClient } from 'graphql-request';
+import flatten from 'lodash/flatten';
+import { fetchEnrichedDataSilos } from './syncDataSilos';
+import {
+  convertToDataSubjectAllowlist,
+  fetchDataSubjects,
+} from './fetchDataSubjects';
+import { fetchApiKeys } from './fetchApiKeys';
+import { fetchAllEnrichers } from './syncEnrichers';
+
+/**
+ * Pull a yaml configuration from Transcend
+ *
+ * @param client - GraphQL client
+ * @returns The configuration
+ */
+export async function pullTranscendConfiguration(
+  client: GraphQLClient,
+): Promise<TranscendInput> {
+  const [dataSubjects, apiKeyTitleMap, dataSilos, enrichers] =
+    await Promise.all([
+      // Grab all data subjects in the organization
+      fetchDataSubjects({}, client, true),
+      // Grab API keys
+      fetchApiKeys({}, client, true),
+      // Fetch the data silos
+      fetchEnrichedDataSilos(client),
+      // Fetch enrichers
+      fetchAllEnrichers(client),
+    ]);
+
+  const result: TranscendInput = {};
+
+  // Save API keys
+  const apiKeyTitles = flatten(
+    dataSilos.map(({ apiKeys }) => apiKeys.map(({ title }) => title)),
+  );
+  const relevantApiKeys = Object.values(apiKeyTitleMap).filter(({ title }) =>
+    apiKeyTitles.includes(title),
+  );
+  if (relevantApiKeys.length > 0) {
+    result['api-keys'] = Object.values(apiKeyTitleMap)
+      .filter(({ title }) => apiKeyTitles.includes(title))
+      .map(
+        ({ title }): ApiKeyInput => ({
+          title,
+        }),
+      );
+  }
+
+  // Save enrichers
+  if (enrichers.length > 0) {
+    result.enrichers = enrichers
+      .filter(({ type }) => type === 'SERVER')
+      .map(
+        ({
+          title,
+          url,
+          inputIdentifier,
+          identifiers,
+          actions,
+        }): EnricherInput => ({
+          title,
+          url,
+          'input-identifier': inputIdentifier.name,
+          'output-identifiers': identifiers.map(({ name }) => name),
+          'privacy-actions': actions,
+        }),
+      );
+  }
+
+  // Save data silos
+  result['data-silos'] = dataSilos.map(
+    ({
+      title,
+      description,
+      url,
+      apiKeys,
+      identifiers,
+      dependentDataSilos,
+      owners,
+      dataPoints,
+      subjectBlocklist,
+      globalActions,
+      isLive,
+    }): DataSiloInput => ({
+      title,
+      description,
+      url: url || undefined,
+      'api-key-title': apiKeys[0]?.title,
+      'identity-keys': identifiers.map(({ name }) => name),
+      'deletion-dependencies': dependentDataSilos.map(({ title }) => title),
+      owners: owners.map(({ email }) => email),
+      disabled: !isLive,
+      'privacy-actions': globalActions
+        .filter(({ active }) => active)
+        .map(({ type }) => type),
+      'data-subjects':
+        subjectBlocklist.length > 0
+          ? convertToDataSubjectAllowlist(
+              subjectBlocklist.map(({ type }) => type),
+              dataSubjects,
+            )
+          : undefined,
+      objects: dataPoints.map((dataPoint) => ({
+        title: dataPoint.title.defaultMessage,
+        description: dataPoint.description.defaultMessage,
+        key: dataPoint.name,
+        purpose: dataPoint.purpose,
+        category: dataPoint.category,
+        'privacy-actions': dataPoint.actionSettings
+          .filter(({ active }) => active)
+          .map(({ type }) => type),
+      })),
+    }),
+  );
+
+  return result;
+}

--- a/src/readTranscendYaml.ts
+++ b/src/readTranscendYaml.ts
@@ -1,6 +1,6 @@
 import { decodeCodec } from '@transcend-io/type-utils';
 import yaml from 'js-yaml';
-import { readFileSync } from 'fs';
+import { readFileSync, writeFileSync } from 'fs';
 import { TranscendInput } from './codecs';
 
 /**
@@ -15,4 +15,17 @@ export function readTranscendYaml(filePath: string): TranscendInput {
     TranscendInput,
     yaml.load(readFileSync(filePath, 'utf-8')),
   );
+}
+
+/**
+ * Write a Transcend configuration to disk
+ *
+ * @param filePath - Path to yaml file
+ * @param input - The input to write out
+ */
+export function writeTranscendYaml(
+  filePath: string,
+  input: TranscendInput,
+): void {
+  writeFileSync(filePath, yaml.dump(decodeCodec(TranscendInput, input)));
 }

--- a/src/readTranscendYaml.ts
+++ b/src/readTranscendYaml.ts
@@ -1,20 +1,41 @@
-import { decodeCodec } from '@transcend-io/type-utils';
+import { decodeCodec, ObjByString } from '@transcend-io/type-utils';
 import yaml from 'js-yaml';
 import { readFileSync, writeFileSync } from 'fs';
 import { TranscendInput } from './codecs';
+
+const PARAMETERS = /<<parameters\.(.+?)>>/;
 
 /**
  * Read in the contents of a yaml file and validate that the shape
  * of the yaml file matches the codec API
  *
  * @param filePath - Path to yaml file
+ * @param variables - Variables to fill in
  * @returns The contents of the yaml file, type-checked
  */
-export function readTranscendYaml(filePath: string): TranscendInput {
-  return decodeCodec(
-    TranscendInput,
-    yaml.load(readFileSync(filePath, 'utf-8')),
-  );
+export function readTranscendYaml(
+  filePath: string,
+  variables: ObjByString = {},
+): TranscendInput {
+  // Read in contents
+  let fileContents = readFileSync(filePath, 'utf-8');
+
+  // Replace variables
+  Object.entries(variables).forEach(([name, value]) => {
+    fileContents = fileContents.split(`<<parameters.${name}>>`).join(value);
+  });
+
+  // Throw error if unfilled variables
+  if (PARAMETERS.test(fileContents)) {
+    const [, name] = PARAMETERS.exec(fileContents) || [];
+    throw new Error(
+      `Found variable that was not set: ${name}.
+Make sure you are passing all parameters through the --parameters=${name}:value-for-param flag.
+Also check that there are no extra variables defined in your yaml: ${filePath}`,
+    );
+  }
+
+  return decodeCodec(TranscendInput, yaml.load(fileContents));
 }
 
 /**

--- a/src/syncEnrichers.ts
+++ b/src/syncEnrichers.ts
@@ -4,6 +4,70 @@ import { ENRICHERS, CREATE_ENRICHER, UPDATE_ENRICHER } from './gqls';
 import { RequestAction } from '@transcend-io/privacy-types';
 import { Identifier } from './fetchIdentifiers';
 
+export interface Enricher {
+  /** ID of enricher */
+  id: string;
+  /** Title of enricher */
+  title: string;
+  /** URL of enricher */
+  url: string;
+  /** Server silo */
+  type: 'SERVER' | 'PERSON';
+  /** Input identifier */
+  inputIdentifier: {
+    /** Identifier name */
+    name: string;
+  };
+  /** The selected actions */
+  actions: RequestAction[];
+  /** Output identifiers */
+  identifiers: {
+    /** Identifier name */
+    name: string;
+  }[];
+}
+
+const PAGE_SIZE = 20;
+
+/**
+ * Fetch all enrichers in the organization
+ *
+ * @param client - GraphQL client
+ * @param title - Filter by title
+ * @returns All enrichers in the organization
+ */
+export async function fetchAllEnrichers(
+  client: GraphQLClient,
+  title?: string,
+): Promise<Enricher[]> {
+  const enrichers: Enricher[] = [];
+  let offset = 0;
+
+  // Try to fetch an enricher with the same title
+  let shouldContinue = false;
+  do {
+    const {
+      enrichers: { nodes },
+      // eslint-disable-next-line no-await-in-loop
+    } = await client.request<{
+      /** Query response */
+      enrichers: {
+        /** List of matches */
+        nodes: Enricher[];
+      };
+    }>(ENRICHERS, {
+      first: PAGE_SIZE,
+      offset,
+      title,
+    });
+    enrichers.push(...nodes);
+    offset += PAGE_SIZE;
+    shouldContinue = nodes.length === PAGE_SIZE;
+  } while (shouldContinue);
+
+  return enrichers;
+}
+
 /**
  * Sync an enricher configuration
  *
@@ -17,32 +81,7 @@ export async function syncEnricher(
   identifiersByName: { [name in string]: Identifier },
 ): Promise<void> {
   // Try to fetch an enricher with the same title
-  const {
-    enrichers: { nodes: matches },
-  } = await client.request<{
-    /** Query response */
-    enrichers: {
-      /** List of matches */
-      nodes: {
-        /** ID of enricher */
-        id: string;
-        /** Title of enricher */
-        title: string;
-        /** Input identifier */
-        inputIdentifier: {
-          /** Identifier name */
-          name: string;
-        };
-        /** Output identifiers */
-        identifiers: {
-          /** Identifier name */
-          name: string;
-        };
-      }[];
-    };
-  }>(ENRICHERS, {
-    title: enricher.title,
-  });
+  const matches = await fetchAllEnrichers(client, enricher.title);
   const existingEnricher = matches.find(
     ({ title }) => title === enricher.title,
   );

--- a/src/tests/readTranscendYaml.test.ts
+++ b/src/tests/readTranscendYaml.test.ts
@@ -26,4 +26,27 @@ describe('readTranscendYaml', () => {
   ".data-silos.0.1.objects.0.1.fields.0.0.key expected type 'string'",
   ".data-silos.1.1.disabled expected type 'boolean'"`);
   });
+
+  it('multi-instance.yml should fail when no variables are provided', () => {
+    expect(() =>
+      readTranscendYaml(join(EXAMPLE_DIR, 'multi-instance.yml')),
+    ).to.throw('Found variable that was not set: domain');
+  });
+
+  it('multi-instance.yml should be successful when variables are provided', () => {
+    const result = readTranscendYaml(join(EXAMPLE_DIR, 'multi-instance.yml'), {
+      domain: 'acme.com',
+      stage: 'Staging',
+    });
+
+    expect(result!.enrichers![0].url).to.equal(
+      'https://example.acme.com/transcend-enrichment-webhook',
+    );
+    expect(result!.enrichers![1].url).to.equal(
+      'https://example.acme.com/transcend-fraud-check',
+    );
+    expect(result!['data-silos']![0].description).to.equal(
+      'The mega-warehouse that contains a copy over all SQL backed databases - Staging',
+    );
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -347,6 +347,9 @@ __metadata:
     ts-node: ^10.4.0
     typescript: ^4.4.4
     yargs-parser: ^21.0.0
+  bin:
+    "transcend:pull": build/cli-pull
+    "transcend:push": build/cli-push
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -348,8 +348,8 @@ __metadata:
     typescript: ^4.4.4
     yargs-parser: ^21.0.0
   bin:
-    "transcend:pull": build/cli-pull
-    "transcend:push": build/cli-push
+    tr-pull: ./build/cli-pull.js
+    tr-push: ./build/cli-push.js
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Related Issues

- closes https://transcend.height.app/T-10781
- closes https://transcend.height.app/T-10778
- closes https://transcend.height.app/T-10779

This PR does a few things:

1. Adds a second script that makes it possible to pull out the existing data map from Transcend and spit it out into a transcend.yaml file. This is useful as a starting point for defining your yaml file, and in the future, gets us closer to a step where configurations can be merged.
2. This package will now be published with the bin commands `yarn tr-pull` and `yarn tr-push`
3. Added the beginning of a README. Adds a section that lists the scopes requires for the generated API key that runs this cli
4. Adds the ability to pass dynamic variables into the .yaml configuration: `tr-push --auth=<api-key> --variables=domain:acme.com,stage:staging`

<img width="827" alt="Screen Shot 2022-01-25 at 10 16 39 PM" src="https://user-images.githubusercontent.com/10264973/151113075-1cc74a13-0d41-4593-8f67-d0866a5eaf88.png">

