### PR TITLE
V2 of cli - drops global actions and adds support for pushing database queries for approval

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-
+transcend.yml
 build/
 
 # Secrets

--- a/README.md
+++ b/README.md
@@ -182,6 +182,12 @@ An alternative file destination can be specified:
 tr-pull --auth=<api-key> --file=./custom/location.yml
 ```
 
+Or a specific data silo(s) can be pulled in:
+
+```sh
+tr-pull --auth=<api-key> --dataSiloIds=710fec3c-7bcc-4c9e-baff-bf39f9bec43e
+```
+
 Note: This command will overwrite the existing transcend.yml file that you have locally.
 
 ### tr-push

--- a/README.md
+++ b/README.md
@@ -124,10 +124,6 @@ data-silos:
     description: The mega-warehouse that contains a copy over all SQL backed databases
     url: https://example.acme.com/transcend-webhook
     api-key-title: Webhook Key
-    privacy-actions:
-      - ACCESS
-      - ERASURE
-      - SALE_OPT_OUT
     data-subjects:
       - customer
       - employee
@@ -141,6 +137,12 @@ data-silos:
     owners:
       - alice@transcend.io
     datapoints:
+      - title: Webhook Notification
+        key: _global
+        privacy-actions:
+          - ACCESS
+          - ERASURE
+          - SALE_OPT_OUT
       - title: User Model
         description: The centralized user model user
         key: users

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ data-silos:
   # Note: title is the only required top-level field for a data silo
   - title: Redshift Data Warehouse
     description: The mega-warehouse that contains a copy over all SQL backed databases
+    integrationName: server
     url: https://example.acme.com/transcend-webhook
     api-key-title: Webhook Key
     data-subjects:
@@ -253,6 +254,7 @@ enrichers:
       - ERASURE
 data-silos:
   - title: Redshift Data Warehouse
+    integrationName: server
     description: The mega-warehouse that contains a copy over all SQL backed databases - <<parameters.stage>>
     url: https://example.<<parameters.domain>>/transcend-webhook
     api-key-title: Webhook Key

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The API key needs the following scopes:
 
 - Manage Data Map
 - Manage Request Identity Verification
-- Connect data silos
+- Connect Data Silos
 - Manage Data Subject Request Settings
 - View API Keys
 

--- a/examples/generated.yml
+++ b/examples/generated.yml
@@ -3,6 +3,7 @@ api-keys:
 enrichers: []
 data-silos:
   - title: Customer.io
+    integrationName: customerIo
     description: >-
       Customer.io is a behavioral messaging platform for triggering personalized
       and event-based customer communication.
@@ -15,6 +16,7 @@ data-silos:
     disabled: true
     datapoints: []
   - title: Facebook Ads
+    integrationName: facebookAds
     description: Targeted ad campaigns on Facebook for businesses.
     identity-keys:
       - email

--- a/examples/generated.yml
+++ b/examples/generated.yml
@@ -13,8 +13,6 @@ data-silos:
     deletion-dependencies: []
     owners: []
     disabled: true
-    privacy-actions:
-      - ERASURE
     datapoints: []
   - title: Facebook Ads
     description: Targeted ad campaigns on Facebook for businesses.
@@ -23,6 +21,4 @@ data-silos:
     deletion-dependencies: []
     owners: []
     disabled: false
-    privacy-actions:
-      - ERASURE
     datapoints: []

--- a/examples/invalid.yml
+++ b/examples/invalid.yml
@@ -20,4 +20,5 @@ data-silos:
             title: Email
             description: The email address of the user
   - title: Analytics Service
+    integrationName: database
     disabled: 'dog'

--- a/examples/invalid.yml
+++ b/examples/invalid.yml
@@ -9,6 +9,7 @@ enrichers:
 
 data-silos:
   - titlez: Redshift Data Warehouse
+    integrationName: database
     deletion-dependencies: Identity Service
     datapoints:
       - description: The centralized user model user

--- a/examples/multi-instance.yml
+++ b/examples/multi-instance.yml
@@ -21,6 +21,7 @@ enrichers:
       - ERASURE
 data-silos:
   - title: Redshift Data Warehouse
+    integrationName: database
     description: The mega-warehouse that contains a copy over all SQL backed databases - <<parameters.stage>>
     url: https://example.<<parameters.domain>>/transcend-webhook
     api-key-title: Webhook Key

--- a/examples/simple.yml
+++ b/examples/simple.yml
@@ -51,6 +51,7 @@ data-silos:
     description: The mega-warehouse that contains a copy over all SQL backed databases
     # The webhook URL to notify for data privacy requests
     url: https://example.acme.com/transcend-webhook
+    integrationName: server
     # The title of the API key that will be used to respond to privacy requests
     api-key-title: Webhook Key
     # Specify which data subjects may have personally-identifiable-information (PII) within this system
@@ -181,6 +182,7 @@ data-silos:
   # at the link: https://app.transcend.io/privacy-requests/connected-services
   - title: Identity Service
     description: Micro-service that stores user metadata
+    integrationName: server
     # Share the API key between services
     api-key-title: Webhook Key
     datapoints:
@@ -195,6 +197,7 @@ data-silos:
         privacy-actions:
           - ACCESS
   - title: Analytics Service
+    integrationName: server
     data-subjects:
       - customer
     # The title of the API key that will be used to respond to privacy requests

--- a/examples/simple.yml
+++ b/examples/simple.yml
@@ -53,21 +53,6 @@ data-silos:
     url: https://example.acme.com/transcend-webhook
     # The title of the API key that will be used to respond to privacy requests
     api-key-title: Webhook Key
-    # The types of privacy actions that this webhook can implement
-    # See "RequestActionObjectResolver": https://github.com/transcend-io/privacy-types/blob/main/src/actions.ts
-    #   AUTOMATED_DECISION_MAKING_OPT_OUT: Opt out of automated decision making
-    #   CONTACT_OPT_OUT: Opt out of all communication
-    #   SALE_OPT_OUT: Opt-out of the sale of personal data
-    #   TRACKING_OPT_OUT: Opt out of tracking
-    #   ACCESS: Data Download request
-    #   ERASURE: Erase the profile from the system
-    #   ACCOUNT_DELETION: Run an account deletion instead of a fully compliant deletion
-    #   RECTIFICATION: Make an update to an inaccurate record
-    #   RESTRICTION: Restrict processing
-    privacy-actions:
-      - ACCESS
-      - ERASURE
-      - SALE_OPT_OUT
     # Specify which data subjects may have personally-identifiable-information (PII) within this system
     # This field can be omitted, and the default assumption will be that the system may potentially
     # contain PII for any potential data subject type.
@@ -95,6 +80,23 @@ data-silos:
     # Note: These are currently called "datapoints" in the Transcend UI and documentation.
     # See: https://docs.transcend.io/docs/the-data-map#datapoints
     datapoints:
+      - title: Webhook Notification
+        key: _global
+        # The types of privacy actions that this webhook can implement
+        # See "RequestActionObjectResolver": https://github.com/transcend-io/privacy-types/blob/main/src/actions.ts
+        #   AUTOMATED_DECISION_MAKING_OPT_OUT: Opt out of automated decision making
+        #   CONTACT_OPT_OUT: Opt out of all communication
+        #   SALE_OPT_OUT: Opt-out of the sale of personal data
+        #   TRACKING_OPT_OUT: Opt out of tracking
+        #   ACCESS: Data Download request
+        #   ERASURE: Erase the profile from the system
+        #   ACCOUNT_DELETION: Run an account deletion instead of a fully compliant deletion
+        #   RECTIFICATION: Make an update to an inaccurate record
+        #   RESTRICTION: Restrict processing
+        privacy-actions:
+          - ACCESS
+          - ERASURE
+          - SALE_OPT_OUT
       - title: User Model
         description: The centralized user model user
         # AKA table name
@@ -181,10 +183,12 @@ data-silos:
     description: Micro-service that stores user metadata
     # Share the API key between services
     api-key-title: Webhook Key
-    privacy-actions:
-      - ACCESS
-      - CONTACT_OPT_OUT
     datapoints:
+      - title: Webhook Notification
+        key: _global
+        privacy-actions:
+          - ACCESS
+          - CONTACT_OPT_OUT
       - title: Auth User
         description: The centralized authentication object for a user
         key: auth

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/schema-sync",
   "description": "Small package containing useful typescript utilities.",
-  "version": "1.4.6",
+  "version": "2.0.0",
   "homepage": "https://github.com/transcend-io/schema-sync",
   "repository": {
     "type": "git",

--- a/src/cli-pull.ts
+++ b/src/cli-pull.ts
@@ -22,6 +22,7 @@ async function main(): Promise<void> {
   const {
     file = './transcend.yml',
     transcendUrl = 'https://api.transcend.io',
+    dataSiloIds = '',
     auth,
   } = yargs(process.argv.slice(2));
 
@@ -47,7 +48,10 @@ async function main(): Promise<void> {
 
   // Sync to Disk
   try {
-    const configuration = await pullTranscendConfiguration(client);
+    const configuration = await pullTranscendConfiguration(
+      client,
+      (dataSiloIds as string).split(',').filter((x) => !!x),
+    );
     writeTranscendYaml(file, configuration);
   } catch (err) {
     logger.error(

--- a/src/codecs.ts
+++ b/src/codecs.ts
@@ -152,13 +152,13 @@ export const DataSiloInput = t.intersection([
   t.type({
     /** The display title of the data silo */
     title: t.string,
-  }),
-  t.partial({
     /**
      * The type of integration. Common internal system types:
      * server | database | cron  | promptAPerson
      */
     integrationName: t.string,
+  }),
+  t.partial({
     /** A description for that data silo */
     description: t.string,
     /** The webhook URL to notify for data privacy requests */

--- a/src/codecs.ts
+++ b/src/codecs.ts
@@ -1,5 +1,5 @@
 import * as t from 'io-ts';
-import { valuesOf } from '@transcend-io/type-utils';
+import { applyEnum, valuesOf } from '@transcend-io/type-utils';
 import {
   DataCategoryType,
   ProcessingPurpose,
@@ -147,11 +147,24 @@ export const DataSiloInput = t.intersection([
   }),
   t.partial({
     /**
+     * The type of integration. Common internal system types:
+     * server | database | cron  | promptAPerson
+     */
+    integrationName: t.string,
+    /**
      * The types of privacy actions that this webhook can implement
      *
      * @see https://github.com/transcend-io/privacy-types/blob/main/src/actions.ts
      */
     'privacy-actions': t.array(valuesOf(RequestActionObjectResolver)),
+    /**
+     * The SQL queries that should be run for that datapoint in a privacy request.
+     *
+     * @see https://github.com/transcend-io/privacy-types/blob/main/src/actions.ts
+     */
+    'privacy-actions-queries': t.partial(
+      applyEnum(RequestActionObjectResolver, () => t.string),
+    ),
     /** A description for that data silo */
     description: t.string,
     /** The webhook URL to notify for data privacy requests */

--- a/src/codecs.ts
+++ b/src/codecs.ts
@@ -116,6 +116,14 @@ export const DatapointInput = t.intersection([
      */
     category: valuesOf(DataCategoryType),
     /**
+     * The SQL queries that should be run for that datapoint in a privacy request.
+     *
+     * @see https://github.com/transcend-io/privacy-types/blob/main/src/actions.ts
+     */
+    'privacy-action-queries': t.partial(
+      applyEnum(RequestActionObjectResolver, () => t.string),
+    ),
+    /**
      * The types of privacy actions that this datapoint can implement
      *
      * @see https://github.com/transcend-io/privacy-types/blob/main/src/actions.ts
@@ -151,14 +159,6 @@ export const DataSiloInput = t.intersection([
      * server | database | cron  | promptAPerson
      */
     integrationName: t.string,
-    /**
-     * The SQL queries that should be run for that datapoint in a privacy request.
-     *
-     * @see https://github.com/transcend-io/privacy-types/blob/main/src/actions.ts
-     */
-    'privacy-action-queries': t.partial(
-      applyEnum(RequestActionObjectResolver, () => t.string),
-    ),
     /** A description for that data silo */
     description: t.string,
     /** The webhook URL to notify for data privacy requests */

--- a/src/codecs.ts
+++ b/src/codecs.ts
@@ -152,17 +152,11 @@ export const DataSiloInput = t.intersection([
      */
     integrationName: t.string,
     /**
-     * The types of privacy actions that this webhook can implement
-     *
-     * @see https://github.com/transcend-io/privacy-types/blob/main/src/actions.ts
-     */
-    'privacy-actions': t.array(valuesOf(RequestActionObjectResolver)),
-    /**
      * The SQL queries that should be run for that datapoint in a privacy request.
      *
      * @see https://github.com/transcend-io/privacy-types/blob/main/src/actions.ts
      */
-    'privacy-actions-queries': t.partial(
+    'privacy-action-queries': t.partial(
       applyEnum(RequestActionObjectResolver, () => t.string),
     ),
     /** A description for that data silo */

--- a/src/gqls.ts
+++ b/src/gqls.ts
@@ -172,6 +172,48 @@ export const DATA_SILO = gql`
   }
 `;
 
+export const DATA_POINTS = gql`
+  query SchemaSyncDataPoints(
+    $dataSiloId: String!
+    $first: Int!
+    $offset: Int!
+  ) {
+    dataPoints(
+      filterBy: { dataSiloId: $dataSiloId }
+      first: $first
+      offset: $offset
+    ) {
+      totalCount
+      nodes {
+        id
+        title {
+          defaultMessage
+        }
+        description {
+          defaultMessage
+        }
+        name
+        purpose
+        category
+        actionSettings {
+          type
+          active
+        }
+      }
+      identifiers {
+        name
+      }
+      dependentDataSilos {
+        title
+      }
+      owners {
+        email
+      }
+      isLive
+    }
+  }
+`;
+
 export const UPDATE_DATA_SILO = gql`
   mutation SchemaSyncUpdateDataSilo(
     $id: ID!

--- a/src/gqls.ts
+++ b/src/gqls.ts
@@ -129,6 +129,7 @@ export const DATA_SILO = gql`
       id
       title
       description
+      type
       url
       apiKeys {
         title
@@ -256,6 +257,7 @@ export const CREATE_DATA_SILO = gql`
     $title: String!
     $description: String!
     $url: String
+    $type: String!
     $identifiers: [String!]
     $isLive: Boolean!
     $dataSubjectBlockListIds: [ID!]
@@ -265,7 +267,7 @@ export const CREATE_DATA_SILO = gql`
   ) {
     connectDataSilo(
       input: {
-        name: "server"
+        name: $type
         title: $title
         description: $description
         url: $url
@@ -280,6 +282,7 @@ export const CREATE_DATA_SILO = gql`
       dataSilo {
         id
         title
+        type
       }
     }
   }

--- a/src/gqls.ts
+++ b/src/gqls.ts
@@ -137,10 +137,6 @@ export const DATA_SILO = gql`
       subjectBlocklist {
         type
       }
-      globalActions {
-        type
-        active
-      }
       dataPoints {
         id
         title {

--- a/src/gqls.ts
+++ b/src/gqls.ts
@@ -227,6 +227,7 @@ export const UPDATE_OR_CREATE_DATA_POINT = gql`
     $description: String
     $category: DataCategoryType
     $purpose: ProcessingPurpose
+    $querySuggestions: [DbIntegrationQuerySuggestionInput!]
     $enabledActions: [RequestActionObjectResolver!]
   ) {
     updateOrCreateDataPoint(
@@ -235,6 +236,7 @@ export const UPDATE_OR_CREATE_DATA_POINT = gql`
         name: $name
         title: $title
         description: $description
+        querySuggestions: $querySuggestions
         category: $category
         purpose: $purpose
         enabledActions: $enabledActions

--- a/src/gqls.ts
+++ b/src/gqls.ts
@@ -115,11 +115,15 @@ export const UPDATE_ENRICHER = gql`
 export const DATA_SILOS = gql`
   query SchemaSyncDataSilos(
     $title: String
+    $ids: [ID!]
     $first: Int!
     $offset: Int!
-    $filterBy: DataSiloFiltersInput
   ) {
-    dataSilos(filterBy: { text: $title }, first: $first, offset: $offset) {
+    dataSilos(
+      filterBy: { text: $title, ids: $ids }
+      first: $first
+      offset: $offset
+    ) {
       nodes {
         id
         title
@@ -142,22 +146,6 @@ export const DATA_SILO = gql`
       subjectBlocklist {
         type
       }
-      dataPoints {
-        id
-        title {
-          defaultMessage
-        }
-        description {
-          defaultMessage
-        }
-        name
-        purpose
-        category
-        actionSettings {
-          type
-          active
-        }
-      }
       identifiers {
         name
       }
@@ -173,13 +161,9 @@ export const DATA_SILO = gql`
 `;
 
 export const DATA_POINTS = gql`
-  query SchemaSyncDataPoints(
-    $dataSiloId: String!
-    $first: Int!
-    $offset: Int!
-  ) {
+  query SchemaSyncDataPoints($dataSiloIds: [ID!], $first: Int!, $offset: Int!) {
     dataPoints(
-      filterBy: { dataSiloId: $dataSiloId }
+      filterBy: { dataSilos: $dataSiloIds }
       first: $first
       offset: $offset
     ) {
@@ -200,16 +184,6 @@ export const DATA_POINTS = gql`
           active
         }
       }
-      identifiers {
-        name
-      }
-      dependentDataSilos {
-        title
-      }
-      owners {
-        email
-      }
-      isLive
     }
   }
 `;

--- a/src/gqls.ts
+++ b/src/gqls.ts
@@ -113,7 +113,12 @@ export const UPDATE_ENRICHER = gql`
 `;
 
 export const DATA_SILOS = gql`
-  query SchemaSyncDataSilos($title: String, $first: Int!, $offset: Int!) {
+  query SchemaSyncDataSilos(
+    $title: String
+    $first: Int!
+    $offset: Int!
+    $filterBy: DataSiloFiltersInput
+  ) {
     dataSilos(filterBy: { text: $title }, first: $first, offset: $offset) {
       nodes {
         id

--- a/src/pullTranscendConfiguration.ts
+++ b/src/pullTranscendConfiguration.ts
@@ -89,7 +89,6 @@ export async function pullTranscendConfiguration(
       owners,
       dataPoints,
       subjectBlocklist,
-      globalActions,
       isLive,
     }): DataSiloInput => ({
       title,
@@ -100,9 +99,6 @@ export async function pullTranscendConfiguration(
       'deletion-dependencies': dependentDataSilos.map(({ title }) => title),
       owners: owners.map(({ email }) => email),
       disabled: !isLive,
-      'privacy-actions': globalActions
-        .filter(({ active }) => active)
-        .map(({ type }) => type),
       'data-subjects':
         subjectBlocklist.length > 0
           ? convertToDataSubjectAllowlist(

--- a/src/pullTranscendConfiguration.ts
+++ b/src/pullTranscendConfiguration.ts
@@ -41,7 +41,7 @@ export async function pullTranscendConfiguration(
 
   // Save API keys
   const apiKeyTitles = flatten(
-    dataSilos.map(({ apiKeys }) => apiKeys.map(({ title }) => title)),
+    dataSilos.map(([{ apiKeys }]) => apiKeys.map(({ title }) => title)),
   );
   const relevantApiKeys = Object.values(apiKeyTitleMap).filter(({ title }) =>
     apiKeyTitles.includes(title),
@@ -79,20 +79,24 @@ export async function pullTranscendConfiguration(
 
   // Save data silos
   result['data-silos'] = dataSilos.map(
-    ({
-      title,
-      description,
-      url,
-      apiKeys,
-      identifiers,
-      dependentDataSilos,
-      owners,
+    ([
+      {
+        title,
+        description,
+        url,
+        type,
+        apiKeys,
+        identifiers,
+        dependentDataSilos,
+        owners,
+        subjectBlocklist,
+        isLive,
+      },
       dataPoints,
-      subjectBlocklist,
-      isLive,
-    }): DataSiloInput => ({
+    ]): DataSiloInput => ({
       title,
       description,
+      integrationName: type,
       url: url || undefined,
       'api-key-title': apiKeys[0]?.title,
       'identity-keys': identifiers.map(({ name }) => name),

--- a/src/pullTranscendConfiguration.ts
+++ b/src/pullTranscendConfiguration.ts
@@ -18,10 +18,12 @@ import { fetchAllEnrichers } from './syncEnrichers';
  * Pull a yaml configuration from Transcend
  *
  * @param client - GraphQL client
+ * @param dataSiloIds - The data silos to sync. If empty list, pull all.
  * @returns The configuration
  */
 export async function pullTranscendConfiguration(
   client: GraphQLClient,
+  dataSiloIds: string[],
 ): Promise<TranscendInput> {
   const [dataSubjects, apiKeyTitleMap, dataSilos, enrichers] =
     await Promise.all([
@@ -30,7 +32,7 @@ export async function pullTranscendConfiguration(
       // Grab API keys
       fetchApiKeys({}, client, true),
       // Fetch the data silos
-      fetchEnrichedDataSilos(client),
+      fetchEnrichedDataSilos(client, { ids: dataSiloIds }),
       // Fetch enrichers
       fetchAllEnrichers(client),
     ]);
@@ -55,7 +57,7 @@ export async function pullTranscendConfiguration(
   }
 
   // Save enrichers
-  if (enrichers.length > 0) {
+  if (enrichers.length > 0 && dataSiloIds.length === 0) {
     result.enrichers = enrichers
       .filter(({ type }) => type === 'SERVER')
       .map(

--- a/src/syncDataSilos.ts
+++ b/src/syncDataSilos.ts
@@ -44,7 +44,7 @@ export async function fetchAllDataSilos(
   client: GraphQLClient,
   {
     title,
-    ids,
+    ids = [],
   }: {
     /** Title */
     title?: string;
@@ -52,6 +52,12 @@ export async function fetchAllDataSilos(
     ids?: string[];
   },
 ): Promise<DataSilo[]> {
+  logger.info(
+    colors.magenta(
+      `Fetching ${ids.length === 0 ? 'all' : ids.length} Data Silos...`,
+    ),
+  );
+
   const dataSilos: DataSilo[] = [];
   let offset = 0;
 
@@ -69,7 +75,7 @@ export async function fetchAllDataSilos(
       };
     }>(DATA_SILOS, {
       first: PAGE_SIZE,
-      filterBy: ids ? { ids } : {},
+      ids: ids.length > 0 ? ids : undefined,
       offset,
       title,
     });
@@ -127,17 +133,17 @@ export async function fetchAllDataPoints(
   let shouldContinue = false;
   do {
     const {
-      dataSilos: { nodes },
+      dataPoints: { nodes },
       // eslint-disable-next-line no-await-in-loop
     } = await client.request<{
       /** Query response */
-      dataSilos: {
+      dataPoints: {
         /** List of matches */
         nodes: DataPoint[];
       };
     }>(DATA_POINTS, {
       first: PAGE_SIZE,
-      dataSiloId,
+      dataSiloIds: [dataSiloId],
       offset,
     });
     dataPoints.push(...nodes);
@@ -276,7 +282,7 @@ export async function syncDataSilo(
     }>(CREATE_DATA_SILO, {
       title: dataSilo.title,
       url: dataSilo.url,
-      type: dataSilo.integrationName || 'server',
+      type: dataSilo.integrationName,
       description: dataSilo.description || '',
       identifiers: dataSilo['identity-keys'],
       isLive: !dataSilo.disabled,

--- a/src/syncDataSilos.ts
+++ b/src/syncDataSilos.ts
@@ -269,6 +269,14 @@ export async function syncDataSilo(
         title: datapoint.title,
         description: datapoint.description,
         category: datapoint.category,
+        querySuggestions: !datapoint['privacy-action-queries']
+          ? undefined
+          : Object.entries(datapoint['privacy-action-queries']).map(
+              ([key, value]) => ({
+                requestType: key,
+                suggestedQuery: value,
+              }),
+            ),
         purpose: datapoint.purpose,
         enabledActions: datapoint['privacy-actions'] || [], // clear out when not specified
       });

--- a/src/syncDataSilos.ts
+++ b/src/syncDataSilos.ts
@@ -51,13 +51,6 @@ export interface DataSiloEnriched {
     /** Type of data subject */
     type: string;
   }[];
-  /** Global actions */
-  globalActions: {
-    /** Whether active */
-    active: boolean;
-    /** Type of action */
-    type: RequestActionObjectResolver;
-  }[];
   /** Datapoints */
   dataPoints: {
     /** ID of dataPoint */
@@ -259,21 +252,6 @@ export async function syncDataSilo(
         : undefined,
     });
     existingDataSilo = connectDataSilo.dataSilo;
-  }
-
-  // Update Global Actions
-  if (!dataSilo.integrationName || dataSilo.integrationName === 'server') {
-    logger.info(
-      colors.magenta(
-        `Syncing data silo level privacy actions for "${dataSilo.title}"...`,
-      ),
-    );
-    await client.request(UPDATE_OR_CREATE_DATA_POINT, {
-      dataSiloId: existingDataSilo!.id,
-      name: '_global',
-      enabledActions: dataSilo['privacy-actions'] || [],
-    });
-    logger.info(colors.green('Synced global actions!'));
   }
 
   // Sync datapoints


### PR DESCRIPTION
- Removes `privacy-actions` top level key for data silos and moves webhook configuration to datapoint
- Adds ability to pull in specific data silos: `tr-pull --auth=<api-key> --dataSiloIds=710fec3c-7bcc-4c9e-baff-bf39f9bec43e`
- Adds ability for datapoint to supply: `privacy-action-queries`
- Adds require dataSilo.integrationName to configuration
- Removes dependencies on deprecated dataSilos.globalActions and unpaginated dataSilos.dataPoints (breaking changes)