### PR TITLE
schema-sync now pulls in SQL queries and suggested queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/schema-sync",
   "description": "Small package containing useful typescript utilities.",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "homepage": "https://github.com/transcend-io/schema-sync",
   "repository": {
     "type": "git",

--- a/src/gqls.ts
+++ b/src/gqls.ts
@@ -183,6 +183,11 @@ export const DATA_POINTS = gql`
           type
           active
         }
+        dbIntegrationQueries {
+          query
+          suggestedQuery
+          requestType
+        }
       }
     }
   }

--- a/src/pullTranscendConfiguration.ts
+++ b/src/pullTranscendConfiguration.ts
@@ -6,6 +6,8 @@ import {
 } from './codecs';
 import { GraphQLClient } from 'graphql-request';
 import flatten from 'lodash/flatten';
+import keyBy from 'lodash/keyBy';
+import mapValues from 'lodash/mapValues';
 import { fetchEnrichedDataSilos } from './syncDataSilos';
 import {
   convertToDataSubjectAllowlist,
@@ -116,6 +118,16 @@ export async function pullTranscendConfiguration(
         key: dataPoint.name,
         purpose: dataPoint.purpose,
         category: dataPoint.category,
+        ...(dataPoint.dbIntegrationQueries.length > 0
+          ? {
+              'privacy-action-queries': mapValues(
+                keyBy(dataPoint.dbIntegrationQueries, 'requestType'),
+                (databaseIntegrationQuery) =>
+                  databaseIntegrationQuery.suggestedQuery ||
+                  databaseIntegrationQuery.query,
+              ),
+            }
+          : {}),
         'privacy-actions': dataPoint.actionSettings
           .filter(({ active }) => active)
           .map(({ type }) => type),

--- a/src/syncDataSilos.ts
+++ b/src/syncDataSilos.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import { DataSiloInput } from './codecs';
 import { GraphQLClient } from 'graphql-request';
 import { logger } from './logger';
@@ -112,6 +113,15 @@ interface DataPoint {
     type: RequestActionObjectResolver;
     /** Is enabled */
     active: boolean;
+  }[];
+  /** Database integration queries */
+  dbIntegrationQueries: {
+    /** Approved query */
+    query: string | null;
+    /** Suggested query */
+    suggestedQuery: string | null;
+    /** Request action */
+    requestType: RequestActionObjectResolver;
   }[];
 }
 
@@ -340,3 +350,4 @@ export async function syncDataSilo(
 
   return existingDataSilo;
 }
+/* eslint-enable max-lines */


### PR DESCRIPTION
## Related Issues

-  related to https://github.com/transcend-io/schema-sync/pull/12

It is now possible to pull down the SQL statements for a database integration. The PR linked above will push updates back into Transcend as suggestions that require approval

<img width="727" alt="Screen Shot 2022-03-09 at 12 57 39 PM" src="https://user-images.githubusercontent.com/10264973/157535001-7e1fe3d4-371b-459d-9b19-a0d4bf21a696.png">
.