### PR TITLE
Fixes identity keys map

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
         args: [--allow-missing-credentials]
       - id: check-yaml
         files: (yaml$|yml$)
-  - repo: git://github.com/thlorenz/doctoc
+  - repo: https://github.com/thlorenz/doctoc
     rev: v1.4.0
     hooks:
       - id: doctoc

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/schema-sync",
   "description": "Small package containing useful typescript utilities.",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "homepage": "https://github.com/transcend-io/schema-sync",
   "repository": {
     "type": "git",

--- a/src/gqls.ts
+++ b/src/gqls.ts
@@ -148,6 +148,7 @@ export const DATA_SILO = gql`
       }
       identifiers {
         name
+        isConnected
       }
       dependentDataSilos {
         title

--- a/src/pullTranscendConfiguration.ts
+++ b/src/pullTranscendConfiguration.ts
@@ -101,7 +101,9 @@ export async function pullTranscendConfiguration(
       integrationName: type,
       url: url || undefined,
       'api-key-title': apiKeys[0]?.title,
-      'identity-keys': identifiers.map(({ name }) => name),
+      'identity-keys': identifiers
+        .filter(({ isConnected }) => isConnected)
+        .map(({ name }) => name),
       'deletion-dependencies': dependentDataSilos.map(({ title }) => title),
       owners: owners.map(({ email }) => email),
       disabled: !isLive,

--- a/src/syncDataSilos.ts
+++ b/src/syncDataSilos.ts
@@ -188,6 +188,8 @@ export interface DataSiloEnriched {
   identifiers: {
     /** Name of identifier */
     name: string;
+    /** True if identifier is wired */
+    isConnected: boolean;
   }[];
   /** Dependent data silos */
   dependentDataSilos: {


### PR DESCRIPTION
Tested this out locally, test coverage for the cli coming soon and tracked in: https://transcend.height.app/T-10772

## Public Changelog

- Fixed: a bug in schema-sync where `tr-pull` was pulling in all identifiers instead of just the configured identifiers.