### PR TITLE
Require category and purpose name

### DIFF
--- a/examples/simple.yml
+++ b/examples/simple.yml
@@ -148,17 +148,23 @@ data-silos:
             description: The first name of the user, inputted during onboarding
             categories:
               - category: USER_PROFILE
+                name: Name
             purposes:
               - purpose: PERSONALIZATION
+                name: Other
           - key: email
             title: Email
             description: The email address of the user
             categories:
               - category: CONTACT
+                name: Email
               - category: USER_PROFILE
+                name: Name
             purposes:
               - purpose: ESSENTIAL
+                name: Login
               - purpose: OPERATION_SECURITY
+                name: Other
       - title: Demo Request
         key: demos
         description: A demo request by someone that does not have a formal account
@@ -172,15 +178,19 @@ data-silos:
             description: The name of the company of the person requesting the demo
             categories:
               - category: CONTACT
+                name: Other
             purposes:
               - purpose: ESSENTIAL
+                name: Demo
           - key: email
             title: Email
             description: The email address to use for coordinating the demo
             categories:
               - category: CONTACT
+                name: Email
             purposes:
               - purpose: ESSENTIAL
+                name: Demo
       - title: Password
         key: passwords
         description: A password for a user
@@ -192,15 +202,19 @@ data-silos:
             description: Hash of the password
             categories:
               - category: OTHER
+                name: Password
             purposes:
               - purpose: OPERATION_SECURITY
+                name: Other
           - key: email
             title: Email
             description: The email address to use for coordinating the demo
             categories:
               - category: CONTACT
+                name: Email
             purposes:
               - purpose: OPERATION_SECURITY
+                name: Other
 
   # Defined web services in addition or instead of databases.
   # The examples below define a subset of the fields.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/cli",
   "description": "Small package containing useful typescript utilities.",
-  "version": "2.2.5",
+  "version": "3.0.0",
   "homepage": "https://github.com/transcend-io/cli",
   "repository": {
     "type": "git",

--- a/src/codecs.ts
+++ b/src/codecs.ts
@@ -67,16 +67,12 @@ export type EnricherInput = t.TypeOf<typeof EnricherInput>;
 /**
  * The data category for a field
  */
-export const ProcessingPurposeInput = t.intersection([
-  t.type({
-    /** The parent purpose */
-    purpose: valuesOf(ProcessingPurpose),
-  }),
-  t.partial({
-    /** User-defined name for this processing purpose sub category. If not specified, will fall back to 'Other' */
-    name: t.string,
-  }),
-]);
+export const ProcessingPurposeInput = t.type({
+  /** The parent purpose */
+  purpose: valuesOf(ProcessingPurpose),
+  /** User-defined name for this processing purpose sub category */
+  name: t.string,
+});
 
 /** Type override */
 export type ProcessingPurposeInput = t.TypeOf<typeof ProcessingPurposeInput>;
@@ -84,16 +80,12 @@ export type ProcessingPurposeInput = t.TypeOf<typeof ProcessingPurposeInput>;
 /**
  * The data category for a field
  */
-export const DataCategoryInput = t.intersection([
-  t.type({
-    /** The parent category */
-    category: valuesOf(DataCategoryType),
-  }),
-  t.partial({
-    /** User-defined name for this sub category. If not specified, will fall back to 'Other' */
-    name: t.string,
-  }),
-]);
+export const DataCategoryInput = t.type({
+  /** The parent category */
+  category: valuesOf(DataCategoryType),
+  /** User-defined name for this sub category */
+  name: t.string,
+});
 
 /** Type override */
 export type DataCategoryInput = t.TypeOf<typeof DataCategoryInput>;
@@ -147,20 +139,6 @@ export const DatapointInput = t.intersection([
   t.partial({
     /** Internal description for why the enricher is needed */
     description: t.string,
-    /**
-     * What is the purpose of processing for this datapoint/table?
-     *
-     * @see https://github.com/transcend-io/privacy-types/blob/main/src/objects.ts
-     * @deprecated - The purpose labels are now associated with fields rather than datapoints to allow for more granularity
-     */
-    purpose: valuesOf(ProcessingPurpose),
-    /**
-     * The category of personal data for this datapoint
-     *
-     * @see https://github.com/transcend-io/privacy-types/blob/main/src/objects.ts
-     * @deprecated - The category labels are now associated with fields rather than datapoints to allow for more granularity
-     */
-    category: valuesOf(DataCategoryType),
     /**
      * The SQL queries that should be run for that datapoint in a privacy request.
      *

--- a/src/graphql/syncDataSilos.ts
+++ b/src/graphql/syncDataSilos.ts
@@ -401,25 +401,15 @@ export async function syncDataSilo(
     await mapSeries(datapoints, async (datapoint) => {
       logger.info(colors.magenta(`Syncing datapoint "${datapoint.key}"...`));
       const fields = datapoint.fields
-        ? datapoint.fields.map((field) => {
-            const categoriesWithFallback = field.categories?.map(
-              (category) => ({
-                name: 'Other',
-                ...category,
-              }),
-            );
-            const purposesWithFallback = field.purposes?.map((purpose) => ({
-              name: 'Other',
-              ...purpose,
-            }));
+        ? datapoint.fields.map(({ key, description, categories, purposes }) =>
             // TODO: Support setting title separately from the 'key/name'
-            return {
-              name: field.key,
-              description: field.description,
-              categories: categoriesWithFallback,
-              purposes: purposesWithFallback,
-            };
-          })
+            ({
+              name: key,
+              description,
+              categories,
+              purposes,
+            }),
+          )
         : undefined;
 
       if (fields && fields.length > 0) {
@@ -435,7 +425,6 @@ export async function syncDataSilo(
         name: datapoint.key,
         title: datapoint.title,
         description: datapoint.description,
-        category: datapoint.category,
         querySuggestions: !datapoint['privacy-action-queries']
           ? undefined
           : Object.entries(datapoint['privacy-action-queries']).map(
@@ -444,7 +433,6 @@ export async function syncDataSilo(
                 suggestedQuery: value,
               }),
             ),
-        purpose: datapoint.purpose,
         enabledActions: datapoint['privacy-actions'] || [], // clear out when not specified
         subDataPoints: fields,
       });


### PR DESCRIPTION
## Description

Requires that the name for the category and purpose be provided when associating them with a subdatapoint. Removes `category` and `purpose` label from datapoint.

## Related Issues

- _[none]_

## Security Implications

_[none]_

## System Availability

_[none]_
