### PR TITLE
Fix email templates sync total count

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ The API key needs the following scopes:
 - Connect Data Silos
 - Manage Data Subject Request Settings
 - View API Keys
+- Manage Email Templates
 
 ## transcend.yml
 

--- a/src/graphql/syncConfigurationToTranscend.ts
+++ b/src/graphql/syncConfigurationToTranscend.ts
@@ -55,8 +55,8 @@ export async function syncConfigurationToTranscend(
           ),
         );
       }
-      logger.info(colors.green(`Synced "${templates.length}" templates!`));
     });
+    logger.info(colors.green(`Synced "${templates.length}" email templates!`));
   }
 
   // Sync enrichers


### PR DESCRIPTION
Moved logging for total count to the end of the process. 

Currently, it gets logged after each email template sync,

```
Syncing template "Communication Opt-Out Report Ready"...
Successfully synced template "Communication Opt-Out Report Ready"!
Synced "31" templates!
Syncing template "Automated Vendor Coordination"...
Successfully synced template "Automated Vendor Coordination"!
Synced "31" templates!
Syncing template "Additional Time Needed"...
Successfully synced template "Additional Time Needed"!
Synced "31" templates!
```
Also, added the `Manage Email Templates` scope in README, for the Transcend API key.
