### PR TITLE
Allow All Types of .txt Files For Python Requirements.txt

### DIFF
--- a/src/cli-discover-silos.ts
+++ b/src/cli-discover-silos.ts
@@ -33,6 +33,7 @@ async function main(): Promise<void> {
     ignoreDirs = '',
     transcendUrl = 'https://api.transcend.io',
     dataSiloId = '',
+    fileGlobs = '',
     auth,
   } = yargs(process.argv.slice(2));
 
@@ -45,7 +46,6 @@ async function main(): Promise<void> {
     );
     process.exit(1);
   }
-
   // Create a GraphQL client
   // eslint-disable-next-line global-require
   const { version } = require('../package.json');
@@ -58,7 +58,12 @@ async function main(): Promise<void> {
 
   const plugin = await fetchActiveSiloDiscoPlugin(client, dataSiloId);
   const config = SILO_DISCOVERY_FUNCTIONS[plugin.dataSilo.type];
-  const results = await findFilesToScan(scanPath, ignoreDirs, config);
+  const results = await findFilesToScan(
+    scanPath,
+    fileGlobs,
+    ignoreDirs,
+    config,
+  );
 
   await uploadSiloDiscoveryResults(client, plugin.id, results);
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,3 @@
-export const ADMIN_DASH = 'https://app.transcend.io/';
+export const ADMIN_DASH = 'https://app.transcend.io';
 
 export const ADMIN_DASH_INTEGRATIONS = `${ADMIN_DASH}/infrastructure/integrations`;

--- a/src/plugins/findFilesToScan.ts
+++ b/src/plugins/findFilesToScan.ts
@@ -17,10 +17,10 @@ export const findFilesToScan = async (
   config: SiloDiscoveryConfig,
 ): Promise<SiloDiscoveryRawResults[]> => {
   const { ignoreDirs: IGNORE_DIRS, supportedFiles, scanFunction } = config;
-  const globsToSupport = supportedFiles;
-  if (fileGlobs !== '') {
-    globsToSupport.push(...fileGlobs.split(','));
-  }
+  const globsToSupport =
+    fileGlobs === ''
+      ? supportedFiles
+      : supportedFiles.concat(fileGlobs.split(','));
   const dirsToIgnore = [...ignoreDirs.split(','), ...IGNORE_DIRS].filter(
     (dir) => dir.length > 0,
   );
@@ -42,6 +42,8 @@ export const findFilesToScan = async (
       resourceId: `${scanPath}/**/${dep}`,
     }));
   } catch (error) {
-    throw new Error(`Error scanning globs ${findFilesToScan}`);
+    throw new Error(
+      `Error scanning globs ${findFilesToScan} with error: ${error}`,
+    );
   }
 };

--- a/src/plugins/findFilesToScan.ts
+++ b/src/plugins/findFilesToScan.ts
@@ -5,33 +5,43 @@ import { SiloDiscoveryConfig, SiloDiscoveryRawResults } from '.';
  * Helper to scan for data silos in all package.json files that it can find in a directory
  *
  * @param scanPath - Where to look for package.json files
+ * @param fileGlobs - Globs to look for
  * @param ignoreDirs - The directories to ignore (excludes node_modules and serverless-build)
  * @param config - Silo Discovery configuration
  * @returns the list of integrations
  */
 export const findFilesToScan = async (
   scanPath: string,
+  fileGlobs: string,
   ignoreDirs: string,
   config: SiloDiscoveryConfig,
 ): Promise<SiloDiscoveryRawResults[]> => {
   const { ignoreDirs: IGNORE_DIRS, supportedFiles, scanFunction } = config;
+  const globsToSupport = supportedFiles;
+  if (fileGlobs !== '') {
+    globsToSupport.push(...fileGlobs.split(','));
+  }
   const dirsToIgnore = [...ignoreDirs.split(','), ...IGNORE_DIRS].filter(
     (dir) => dir.length > 0,
   );
-  const filesToScan: string[] = await fastGlob(
-    `${scanPath}/**/${supportedFiles.join('|')}`,
-    {
-      ignore: dirsToIgnore.map((dir: string) => `${scanPath}/**/${dir}`),
-      unique: true,
-      onlyFiles: true,
-    },
-  );
-  const allDeps = filesToScan
-    .map((filePath: string) => scanFunction(filePath))
-    .flat();
-  const uniqueDeps = new Set(allDeps);
-  return [...uniqueDeps].map((dep) => ({
-    name: dep,
-    resourceId: `${scanPath}/**/${dep}`,
-  }));
+  try {
+    const filesToScan: string[] = await fastGlob(
+      `${scanPath}/**/${globsToSupport.join('|')}`,
+      {
+        ignore: dirsToIgnore.map((dir: string) => `${scanPath}/**/${dir}`),
+        unique: true,
+        onlyFiles: true,
+      },
+    );
+    const allDeps = filesToScan
+      .map((filePath: string) => scanFunction(filePath))
+      .flat();
+    const uniqueDeps = new Set(allDeps);
+    return [...uniqueDeps].map((dep) => ({
+      name: dep,
+      resourceId: `${scanPath}/**/${dep}`,
+    }));
+  } catch (error) {
+    throw new Error(`Error scanning globs ${findFilesToScan}`);
+  }
 };

--- a/src/plugins/integrations/pythonRequirementsTxt.ts
+++ b/src/plugins/integrations/pythonRequirementsTxt.ts
@@ -2,7 +2,7 @@ import { readFileSync } from 'fs';
 import { SiloDiscoveryConfig } from '../types';
 
 export const pythonRequirementsTxt: SiloDiscoveryConfig = {
-  supportedFiles: ['**.txt'],
+  supportedFiles: ['requirements.txt'],
   ignoreDirs: ['build', 'lib', 'lib64'],
   scanFunction: (filePath) => {
     const lines = readFileSync(filePath)

--- a/src/plugins/integrations/pythonRequirementsTxt.ts
+++ b/src/plugins/integrations/pythonRequirementsTxt.ts
@@ -2,7 +2,7 @@ import { readFileSync } from 'fs';
 import { SiloDiscoveryConfig } from '../types';
 
 export const pythonRequirementsTxt: SiloDiscoveryConfig = {
-  supportedFiles: ['requirements.txt'],
+  supportedFiles: ['**.txt'],
   ignoreDirs: ['build', 'lib', 'lib64'],
   scanFunction: (filePath) => {
     const lines = readFileSync(filePath)


### PR DESCRIPTION
## Related Issues

- link - https://transcend.height.app/T-16536

## System Availability

- Pass in a glob that accepts all types of .txt files
