### PR TITLE
Fix resourceID in tr-discover-silos

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/cli",
   "description": "Small package containing useful typescript utilities.",
-  "version": "4.4.2",
+  "version": "4.4.3",
   "homepage": "https://github.com/transcend-io/cli",
   "repository": {
     "type": "git",

--- a/src/plugins/findFilesToScan.ts
+++ b/src/plugins/findFilesToScan.ts
@@ -40,7 +40,7 @@ export const findFilesToScan = async (
     return [...uniqueDeps].map((dep) => ({
       name: dep.name,
       type: dep.type,
-      resourceId: `${scanPath}/**/${dep}`,
+      resourceId: `${scanPath}/**/${dep.name}`,
     }));
   } catch (error) {
     throw new Error(


### PR DESCRIPTION
## Related Issues

- link - https://transcend.height.app/T-16563
- resourceID was passing in [object], which resulted in all the recommendations being overwritten
