### PR TITLE
Add Regex to Detect Gradle Plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/cli",
   "description": "Small package containing useful typescript utilities.",
-  "version": "4.4.4",
+  "version": "4.4.5",
   "homepage": "https://github.com/transcend-io/cli",
   "repository": {
     "type": "git",

--- a/src/plugins/integrations/gradle.ts
+++ b/src/plugins/integrations/gradle.ts
@@ -10,7 +10,12 @@ import { SiloDiscoveryConfig } from '../types';
  * where the middle is the name of the dependency
  *
  */
-const regex = [/:(.\S*):/, /name: ?'(.*?)'/];
+const regex = [
+  /:(.\S*):/,
+  /name: ?[",'](.*?)[",']/,
+  /id [",'](.*?)[",'] version/,
+  /id ?\([",'](.*?)[",']\)/,
+];
 
 const SPECIAL_CASE_MAP: Record<string, string | undefined> = {};
 


### PR DESCRIPTION
- Some dependencies were also inside the plugin like this
```
buildscript {
    repositories {
        mavenCentral()
    }
}

plugins {
    id "io.sentry.android.gradle" version "3.1.4"
}
```