### PR TITLE
Split attributes out into own columns

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/cli",
   "description": "Small package containing useful typescript utilities.",
-  "version": "4.17.1",
+  "version": "4.18.0",
   "homepage": "https://github.com/transcend-io/cli",
   "repository": {
     "type": "git",

--- a/src/cron/pullCronIdentifiersToCsv.ts
+++ b/src/cron/pullCronIdentifiersToCsv.ts
@@ -73,11 +73,15 @@ export async function pullCronIdentifiersToCsv({
   // Write out to CSV
   writeCsv(
     file,
-    identifiers.map((identifier) => ({
+    identifiers.map(({ attributes, ...identifier }) => ({
       ...identifier,
-      attributes: identifier.attributes
-        .map((attr) => `${attr.key}:${attr.values.join(';')}`)
-        .join(','),
+      ...attributes.reduce(
+        (acc, val) =>
+          Object.assign(acc, {
+            [val.key]: val.values.join(','),
+          }),
+        {},
+      ),
     })),
   );
 


### PR DESCRIPTION
When pulling in request attributes, add each attribute key to its own column.