### PR TITLE
Adds a cli command to restart privacy requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,18 @@
     - [Authentication](#authentication-3)
     - [Arguments](#arguments-3)
   - [Usage](#usage-4)
-  - [tr-cron-pull-identifiers](#tr-cron-pull-identifiers)
+  - [tr-request-restart](#tr-request-restart)
     - [Authentication](#authentication-4)
     - [Arguments](#arguments-4)
   - [Usage](#usage-5)
-  - [tr-cron-mark-identifiers-completed](#tr-cron-mark-identifiers-completed)
+  - [tr-cron-pull-identifiers](#tr-cron-pull-identifiers)
     - [Authentication](#authentication-5)
     - [Arguments](#arguments-5)
   - [Usage](#usage-6)
+  - [tr-cron-mark-identifiers-completed](#tr-cron-mark-identifiers-completed)
+    - [Authentication](#authentication-6)
+    - [Arguments](#arguments-6)
+  - [Usage](#usage-7)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -51,11 +55,13 @@ If your codebase is typescript or javascript based, you can add this package as 
 yarn add -D @transcend-io/cli
 
 # cli commands available within package
-yarn tr-pull --auth=xxx
-yarn tr-push --auth=xxx
-yarn tr-discover-silos --auth=xxx
-yarn tr-request-upload --auth=xxx
-yarn tr-cron-pull-identifiers --auth=xxx
+yarn tr-pull --auth=$TRANSCEND_API_KEY
+yarn tr-push --auth=$TRANSCEND_API_KEY
+yarn tr-discover-silos --auth=$TRANSCEND_API_KEY
+yarn tr-request-upload --auth=$TRANSCEND_API_KEY
+yarn tr-request-restart --auth=$TRANSCEND_API_KEY
+yarn tr-cron-pull-identifiers --auth=$TRANSCEND_API_KEY
+yarn tr-cron-mark-identifiers-completed --auth=$TRANSCEND_API_KEY
 ```
 
 or
@@ -65,11 +71,13 @@ or
 npm i -D @transcend-io/cli
 
 # cli commands available within package
-tr-pull --auth=xxx
-tr-push --auth=xxx
-tr-discover-silos --auth=xxx
-tr-request-upload --auth=xxx
-tr-cron-pull-identifiers --auth=xxx
+tr-pull --auth=$TRANSCEND_API_KEY
+tr-push --auth=$TRANSCEND_API_KEY
+tr-discover-silos --auth=$TRANSCEND_API_KEY
+tr-request-upload --auth=$TRANSCEND_API_KEY
+tr-request-restart --auth=$TRANSCEND_API_KEY
+tr-cron-pull-identifiers --auth=$TRANSCEND_API_KEY
+tr-cron-mark-identifiers-completed --auth=$TRANSCEND_API_KEY
 ```
 
 alternatively, you can install the cli globally on your machine:
@@ -79,10 +87,13 @@ alternatively, you can install the cli globally on your machine:
 npm i -g @transcend-io/cli
 
 # cli commands available everywhere on machine
-tr-pull --auth=xxx
-tr-push --auth=xxx
-tr-discover-silos --auth=xxx
-tr-request-upload --auth=xxx
+tr-pull --auth=$TRANSCEND_API_KEY
+tr-push --auth=$TRANSCEND_API_KEY
+tr-discover-silos --auth=$TRANSCEND_API_KEY
+tr-request-upload --auth=$TRANSCEND_API_KEY
+tr-request-restart --auth=$TRANSCEND_API_KEY
+tr-cron-pull-identifiers --auth=$TRANSCEND_API_KEY
+tr-cron-mark-identifiers-completed --auth=$TRANSCEND_API_KEY
 ```
 
 Note:
@@ -523,10 +534,10 @@ yarn tr-request-upload --auth=$TRANSCEND_API_KEY --file=/Users/transcend/Desktop
    --isSilent=false --emailIsVerified=false
 ```
 
-Increase the concurrency (defaults to 20)
+Increase the concurrency (defaults to 100)
 
 ```sh
-yarn tr-request-upload --auth=$TRANSCEND_API_KEY --file=/Users/transcend/Desktop/test.csv --concurrency=20
+yarn tr-request-upload --auth=$TRANSCEND_API_KEY --file=/Users/transcend/Desktop/test.csv --concurrency=100
 ```
 
 Tag all uploaded requests with an attribute
@@ -546,6 +557,98 @@ Include debug logs - warning, this logs out personal data.
 
 ```sh
 yarn tr-request-upload --auth=$TRANSCEND_API_KEY --file=/Users/transcend/Desktop/test.csv --debug=true
+```
+
+### tr-request-restart
+
+Bulk update a set of privacy requests based on a set of request filters.
+
+#### Authentication
+
+In order to use this cli, you will first need to generate an API key on the Transcend Admin Dashboard (https://app.transcend.io/infrastructure/api-keys).
+
+The API key needs the following scopes:
+
+- Submit New Data Subject Request
+- View the Request Compilation
+
+#### Arguments
+
+| Argument             | Description                                                                                                                               | Type            | Default                           | Required |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | --------------- | --------------------------------- | -------- |
+| auth                 | The Transcend API capable of submitting privacy requests.                                                                                 | string          | N/A                               | true     |
+| acions               | The [request action](https://docs.transcend.io/docs/privacy-requests/configuring-requests/data-subject-requests#data-actions) to restart. | RequestAction[] | N/A                               | true     |
+| statuses             | The [request statuses](https://docs.transcend.io/docs/privacy-requests/overview#request-statuses) to restart.                             | RequestStatus[] | N/A                               | true     |
+| transcendUrl         | URL of the Transcend backend. Use https://api.us.transcend.io for US hosting.                                                             | string - URL    | https://api.transcend.io          | false    |
+| requestReceiptFolder | The path to the folder where receipts of each upload are stored. This allows for debugging of errors.                                     | string          | ./privacy-request-upload-receipts | false    |
+| sombraAuth           | The sombra internal key, use for additional authentication when self-hosting sombra.                                                      | string          | N/A                               | false    |
+| concurrency          | The concurrency to use when uploading requests in parallel.                                                                               | number          | 20                                | false    |
+| requestIds           | Specify the specific request IDs to restart                                                                                               | string[]        | []                                | false    |
+| createdAt            | Restart requests that were submitted before a specific date.                                                                              | Date            | Date.now()                        | false    |
+| markSilent           | Requests older than this date should be marked as silent mode                                                                             | Date            | Date.now() - 3 months             | false    |
+| sendEmailReceipt     | Send email receipts to the restarted requests                                                                                             | boolean         | false                             | false    |
+| copyIdentifiers      | Copy over all enriched identifiers from the initial request. Leave false to restart from scratch with initial identifiers only.           | boolean         | false                             | false    |
+| skipWaitingPeriod    | Skip queued state of request and go straight to compiling                                                                                 | boolean         | false                             | false    |
+
+### Usage
+
+```sh
+yarn tr-request-restart --auth=$TRANSCEND_API_KEY --statuses=COMPILING,ENRICHING --actions=ACCESS,ERASURE
+```
+
+For self-hosted sombras that use an internal key:
+
+```sh
+yarn tr-request-restart --auth=$TRANSCEND_API_KEY --sombraAuth=$SOMBRA_INTERNAL_KEY --statuses=COMPILING,ENRICHING --actions=ACCESS,ERASURE
+```
+
+Specifying the backend URL, needed for US hosted backend infrastructure.
+
+```sh
+yarn tr-request-restart --auth=$TRANSCEND_API_KEY --sombraAuth=$SOMBRA_INTERNAL_KEY --statuses=COMPILING,ENRICHING --actions=ACCESS,ERASURE \
+ --transcendUrl=https://api.us.transcend.io
+```
+
+Increase the concurrency (defaults to 20)
+
+```sh
+yarn tr-request-restart --auth=$TRANSCEND_API_KEY --statuses=COMPILING,ENRICHING --actions=ACCESS,ERASURE --concurrency=100
+```
+
+Restart specific requests by ID
+
+```sh
+yarn tr-request-restart --auth=$TRANSCEND_API_KEY --statuses=COMPILING,ENRICHING --actions=ACCESS,ERASURE --requestIds=c3ae78c9-2768-4666-991a-d2f729503337,342e4bd1-64ea-4af0-a4ad-704b5a07cfe4
+```
+
+Restart requests that were submitted before a specific date.
+
+```sh
+yarn tr-request-restart --auth=$TRANSCEND_API_KEY --statuses=COMPILING,ENRICHING --actions=ACCESS,ERASURE --createdAt=2022-05-11T00:46
+```
+
+Restart requests and place everything in silent mode submitted before a certain date
+
+```sh
+yarn tr-request-restart --auth=$TRANSCEND_API_KEY --statuses=COMPILING,ENRICHING --actions=ACCESS,ERASURE --markSilent=2022-12-05T00:46
+```
+
+Send email receipts to the restarted requests
+
+```sh
+yarn tr-request-restart --auth=$TRANSCEND_API_KEY --statuses=COMPILING,ENRICHING --actions=ACCESS,ERASURE --sendEmailReceipt=true
+```
+
+Copy over all enriched identifiers from the initial request. Leave false to restart from scratch with initial identifiers only
+
+```sh
+yarn tr-request-restart --auth=$TRANSCEND_API_KEY --statuses=COMPILING,ENRICHING --actions=ACCESS,ERASURE --copyIdentifiers=true
+```
+
+Skip queued state of request and go straight to compiling
+
+```sh
+yarn tr-request-restart --auth=$TRANSCEND_API_KEY --statuses=COMPILING,ENRICHING --actions=ACCESS,ERASURE --skipWaitingPeriod=true
 ```
 
 ### tr-cron-pull-identifiers

--- a/src/cli-request-restart.ts
+++ b/src/cli-request-restart.ts
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+
+import yargs from 'yargs-parser';
+import colors from 'colors';
+
+import { logger } from './logger';
+import { splitCsvToList, bulkRestartRequests } from './requests';
+import { RequestAction, RequestStatus } from '@transcend-io/privacy-types';
+
+const ONE_MONTH = 30.5 * 24 * 60 * 60 * 1000;
+
+/**
+ * Run a command to bulk restart a set of privacy requests
+ *
+ * Requires an API key with follow scopes: https://app.transcend.io/infrastructure/api-keys
+ *    - "Submit New Data Subject Request"
+ *    - "View the Request Compilation"
+ *
+ * Dev Usage:
+ * yarn ts-node ./src/cli-request-restart.ts --auth=asd123 \
+ *   --statuses=COMPILING,APPROVING --actions=ERASURE
+ *
+ * Standard usage:
+ * yarn tr-request-restart --auth=asd123 \
+ *   --statuses=COMPILING,APPROVING --actions=ERASURE
+ */
+async function main(): Promise<void> {
+  // Parse command line arguments
+  const {
+    auth,
+    transcendUrl = 'https://api.transcend.io',
+    sombraAuth,
+    /** Restart requests matching these request actions */
+    actions,
+    /** Restart requests matching these request statuses */
+    statuses,
+    /** Concurrency to restart requests at */
+    concurrency = '20',
+    /** List of request IDs */
+    requestIds = '',
+    /** Filter for requests that were submitted before this date */
+    createdAt = new Date().toISOString(),
+    /** Requests that have been open for this length of time should be marked as silent mode */
+    markSilent = new Date(+new Date() - ONE_MONTH * 3).toISOString(),
+    /** Send an email receipt to the restarted requests */
+    sendEmailReceipt = 'false',
+    /** Copy over all identifiers rather than restarting the request only with the core identifier */
+    copyIdentifiers = 'false',
+    /** Skip the waiting period when restarting requests */
+    skipWaitingPeriod = 'false',
+    /** Include a receipt of the requests that were restarted in this file */
+    requestReceiptFolder = './privacy-request-upload-receipts',
+  } = yargs(process.argv.slice(2)) as { [k in string]: string };
+
+  // Ensure auth is passed
+  if (!auth) {
+    logger.error(
+      colors.red(
+        'A Transcend API key must be provided. You can specify using --auth=asd123',
+      ),
+    );
+    process.exit(1);
+  }
+
+  // Parse request actions
+  if (!actions) {
+    logger.error(
+      colors.red(
+        'Missing required parameter "actions". e.g. --actions=ERASURE,ACCESS',
+      ),
+    );
+    process.exit(1);
+  }
+  const requestActions = actions.split(',') as RequestAction[];
+  const invalidActions = requestActions.filter(
+    (action) => !Object.values(RequestAction).includes(action),
+  );
+  if (invalidActions.length > 0) {
+    logger.error(
+      colors.red(
+        `Received invalid action values: "${invalidActions.join(',')}"`,
+      ),
+    );
+    process.exit(1);
+  }
+
+  // Parse request statuses
+  if (!statuses) {
+    logger.error(
+      colors.red(
+        'Missing required parameter "statuses". e.g. --statuses=COMPILING,APPROVING',
+      ),
+    );
+    process.exit(1);
+  }
+  const requestStatuses = statuses.split(',') as RequestStatus[];
+  const invalidStatuses = requestStatuses.filter(
+    (status) => !Object.values(RequestStatus).includes(status),
+  );
+  if (invalidStatuses.length > 0) {
+    logger.error(
+      colors.red(
+        `Received invalid status values: "${invalidStatuses.join(',')}"`,
+      ),
+    );
+    process.exit(1);
+  }
+
+  // Upload privacy requests
+  await bulkRestartRequests({
+    requestReceiptFolder,
+    auth,
+    sombraAuth,
+    requestActions,
+    requestStatuses,
+    requestIds: splitCsvToList(requestIds),
+    createdAt: new Date(createdAt),
+    markSilent: new Date(markSilent),
+    sendEmailReceipt: sendEmailReceipt === 'true',
+    copyIdentifiers: copyIdentifiers === 'true',
+    skipWaitingPeriod: skipWaitingPeriod === 'true',
+    concurrency: parseInt(concurrency, 10),
+    transcendUrl,
+  });
+}
+
+main();

--- a/src/graphql/fetchAllRequestIdentifiers.ts
+++ b/src/graphql/fetchAllRequestIdentifiers.ts
@@ -1,0 +1,56 @@
+import { GraphQLClient } from 'graphql-request';
+import { REQUEST_IDENTIFIERS } from './gqls';
+import { makeGraphQLRequest } from './makeGraphQLRequest';
+
+export interface RequestIdentifier {
+  /** ID of request */
+  id: string;
+  /** Name of identifier */
+  name: string;
+  /** The underlying identifier value */
+  value: string;
+  /** Whether request identifier has been verified at least one */
+  isVerifiedAtLeastOnce: boolean;
+  /** Whether request identifier has been verified */
+  isVerified: boolean;
+}
+
+const PAGE_SIZE = 50;
+
+/**
+ * Fetch all request identifiers for a particular request
+ *
+ * @param client - GraphQL client
+ * @param options - Filter options
+ * @returns List of request identifiers
+ */
+export async function fetchAllRequestIdentifiers(
+  client: GraphQLClient,
+  {
+    requestId,
+  }: {
+    /** ID of request to filter on */
+    requestId: string;
+  },
+): Promise<RequestIdentifier[]> {
+  const requestIdentifiers: RequestIdentifier[] = [];
+  let offset = 0;
+
+  // Paginate
+  let shouldContinue = false;
+  do {
+    const {
+      requestIdentifiers: { nodes },
+      // eslint-disable-next-line no-await-in-loop
+    } = await makeGraphQLRequest(client, REQUEST_IDENTIFIERS, {
+      first: PAGE_SIZE,
+      offset,
+      requestId,
+    });
+    requestIdentifiers.push(...nodes);
+    offset += PAGE_SIZE;
+    shouldContinue = nodes.length === PAGE_SIZE;
+  } while (shouldContinue);
+
+  return requestIdentifiers;
+}

--- a/src/graphql/fetchAllRequests.ts
+++ b/src/graphql/fetchAllRequests.ts
@@ -1,0 +1,89 @@
+import { GraphQLClient } from 'graphql-request';
+import colors from 'colors';
+import { REQUESTS } from './gqls';
+import { makeGraphQLRequest } from './makeGraphQLRequest';
+import {
+  RequestAction,
+  RequestStatus,
+  IsoCountryCode,
+  IsoCountrySubdivisionCode,
+} from '@transcend-io/privacy-types';
+import { logger } from '../logger';
+import { LanguageKey } from '@transcend-io/internationalization';
+
+export interface PrivacyRequest {
+  /** ID of request */
+  id: string;
+  /** Time request was made */
+  createdAt: string;
+  /** Email of request */
+  email: string;
+  /** Link for request */
+  link: string;
+  /** Whether request is in test mode */
+  isTest: boolean;
+  /** Request details */
+  details: string;
+  /** Locale of request */
+  locale: LanguageKey;
+  /** Whether request is in silent mode */
+  isSilent: boolean;
+  /** Core identifier of request */
+  coreIdentifier: string;
+  /** Type of request action */
+  type: RequestAction;
+  /** Type of data subject */
+  subjectType: string;
+  /** Country of request */
+  country?: IsoCountryCode | null;
+  /** Sub division of request */
+  countrySubDivision?: IsoCountrySubdivisionCode | null;
+}
+
+const PAGE_SIZE = 50;
+
+/**
+ * Fetch all requests matching a set of filters
+ *
+ * @param client - GraphQL client
+ * @param options - Filter options
+ * @returns List of requests
+ */
+export async function fetchAllRequests(
+  client: GraphQLClient,
+  {
+    actions,
+    statuses,
+  }: {
+    /** Actions to filter on */
+    actions: RequestAction[];
+    /** Statuses to filter on */
+    statuses: RequestStatus[];
+  },
+): Promise<PrivacyRequest[]> {
+  const requests: PrivacyRequest[] = [];
+  let offset = 0;
+
+  // Paginate
+  let shouldContinue = false;
+  do {
+    const {
+      requests: { nodes, totalCount },
+      // eslint-disable-next-line no-await-in-loop
+    } = await makeGraphQLRequest(client, REQUESTS, {
+      first: PAGE_SIZE,
+      offset,
+      actions,
+      statuses,
+    });
+    if (offset === 0 && totalCount > PAGE_SIZE) {
+      logger.info(colors.magenta(`Fetching ${totalCount} requests`));
+    }
+
+    requests.push(...nodes);
+    offset += PAGE_SIZE;
+    shouldContinue = nodes.length === PAGE_SIZE;
+  } while (shouldContinue);
+
+  return requests;
+}

--- a/src/graphql/fetchApiKeys.ts
+++ b/src/graphql/fetchApiKeys.ts
@@ -9,7 +9,7 @@ import { TranscendInput } from '../codecs';
 import { makeGraphQLRequest } from './makeGraphQLRequest';
 
 export interface ApiKey {
-  /** ID of APi key */
+  /** ID of API key */
   id: string;
   /** Title of API key */
   title: string;

--- a/src/graphql/gqls/RequestIdentifier.ts
+++ b/src/graphql/gqls/RequestIdentifier.ts
@@ -1,0 +1,24 @@
+import { gql } from 'graphql-request';
+
+export const REQUEST_IDENTIFIERS = gql`
+  query TranscendCliRequestIdentifiers(
+    $first: Int!
+    $offset: Int!
+    $requestId: ID!
+  ) {
+    requestIdentifiers(
+      input: { requestId: $requestId }
+      first: $first
+      offset: $offset
+    ) {
+      nodes {
+        id
+        name
+        value
+        isVerifiedAtLeastOnce
+        isVerified
+      }
+      totalCount
+    }
+  }
+`;

--- a/src/graphql/gqls/index.ts
+++ b/src/graphql/gqls/index.ts
@@ -8,3 +8,5 @@ export * from './siloDiscovery';
 export * from './template';
 export * from './organization';
 export * from './attributeKey';
+export * from './request';
+export * from './RequestIdentifier';

--- a/src/graphql/gqls/request.ts
+++ b/src/graphql/gqls/request.ts
@@ -1,0 +1,33 @@
+import { gql } from 'graphql-request';
+
+export const REQUESTS = gql`
+  query TranscendCliRequests(
+    $first: Int!
+    $offset: Int!
+    $actions: [RequestAction!]!
+    $statuses: [RequestStatus!]!
+  ) {
+    requests(
+      filterBy: { type: $actions, status: $statuses }
+      first: $first
+      offset: $offset
+    ) {
+      nodes {
+        id
+        createdAt
+        email
+        link
+        details
+        isTest
+        locale
+        isSilent
+        coreIdentifier
+        type
+        subjectType
+        country
+        countrySubDivision
+      }
+      totalCount
+    }
+  }
+`;

--- a/src/graphql/index.ts
+++ b/src/graphql/index.ts
@@ -13,3 +13,5 @@ export * from './createSombraGotInstance';
 export * from './buildTranscendGraphQLClient';
 export * from './gqls';
 export * from './fetchAllAttributeKeys';
+export * from './fetchAllRequests';
+export * from './fetchAllRequestIdentifiers';

--- a/src/requests/bulkRestartRequests.ts
+++ b/src/requests/bulkRestartRequests.ts
@@ -1,0 +1,237 @@
+import * as t from 'io-ts';
+import difference from 'lodash/difference';
+import { map } from 'bluebird';
+import cliProgress from 'cli-progress';
+import colors from 'colors';
+import { join } from 'path';
+import { RequestAction, RequestStatus } from '@transcend-io/privacy-types';
+import { PersistedState } from '@transcend-io/persisted-state';
+import { logger } from '../logger';
+import { restartPrivacyRequest } from './restartPrivacyRequest';
+import {
+  buildTranscendGraphQLClient,
+  createSombraGotInstance,
+  fetchAllRequests,
+  fetchAllRequestIdentifiers,
+} from '../graphql';
+import { extractClientError } from './extractClientError';
+import { SuccessfulRequest } from './constants';
+
+/** Minimal state we need to keep a list of requests */
+const ErrorRequest = t.intersection([
+  SuccessfulRequest,
+  t.type({
+    error: t.string,
+  }),
+]);
+
+/** Type override */
+type ErrorRequest = t.TypeOf<typeof ErrorRequest>;
+
+/** Persist this data between runs of the script */
+const CachedRequestState = t.type({
+  restartedRequests: t.array(SuccessfulRequest),
+  failingRequests: t.array(ErrorRequest),
+});
+
+/**
+ * Upload a set of privacy requests from CSV
+ *
+ * @param options - Options
+ */
+export async function bulkRestartRequests({
+  requestReceiptFolder,
+  auth,
+  sombraAuth,
+  requestActions,
+  requestStatuses,
+  transcendUrl = 'https://api.transcend.io',
+  requestIds = [],
+  createdAt = new Date(),
+  markSilent,
+  sendEmailReceipt = false,
+  copyIdentifiers = false,
+  skipWaitingPeriod = false,
+  concurrency = 20,
+}: {
+  /** Actions to filter for */
+  requestActions: RequestAction[];
+  /** Statues to filter for */
+  requestStatuses: RequestStatus[];
+  /** File where request receipts are stored */
+  requestReceiptFolder: string;
+  /** Transcend API key authentication */
+  auth: string;
+  /** API URL for Transcend backend */
+  transcendUrl?: string;
+  /** Sombra API key authentication */
+  sombraAuth?: string;
+  /** Request IDs to filter for */
+  requestIds?: string[];
+  /** Filter for requests that were submitted before this date */
+  createdAt?: Date;
+  /** Requests that have been open for this length of time should be marked as silent mode */
+  markSilent?: Date;
+  /** Send an email receipt to the restarted requests */
+  sendEmailReceipt?: boolean;
+  /** Copy over all identifiers rather than restarting the request only with the core identifier */
+  copyIdentifiers?: boolean;
+  /** Skip the waiting period when restarting requests */
+  skipWaitingPeriod?: boolean;
+  /** Concurrency to upload requests at */
+  concurrency?: number;
+}): Promise<void> {
+  // Time duration
+  const t0 = new Date().getTime();
+  // create a new progress bar instance and use shades_classic theme
+  const progressBar = new cliProgress.SingleBar(
+    {},
+    cliProgress.Presets.shades_classic,
+  );
+
+  // Create a new state file to store the requests from this run
+  const cacheFile = join(
+    requestReceiptFolder,
+    `tr-request-restart-${new Date().toISOString()}`,
+  );
+  const state = new PersistedState(cacheFile, CachedRequestState, {
+    restartedRequests: [],
+    failingRequests: [],
+  });
+
+  // Create sombra instance to communicate with
+  const sombra = await createSombraGotInstance(transcendUrl, auth, sombraAuth);
+
+  // Find all requests made before createdAt that are in a removing data state
+  const client = buildTranscendGraphQLClient(transcendUrl, auth);
+
+  logger.info(colors.magenta('Fetching requests to restart...'));
+
+  const allRequests = await fetchAllRequests(client, {
+    actions: requestActions,
+    statuses: requestStatuses,
+  });
+  const requests = allRequests.filter(
+    (request) =>
+      new Date(request.createdAt) < createdAt &&
+      (requestIds.length === 0 || requestIds.includes(request.id)),
+  );
+  logger.info(`Found ${requests.length} requests to process`);
+
+  if (copyIdentifiers) {
+    logger.info('copyIdentifiers detected - All Identifiers will be copied.');
+  }
+  if (sendEmailReceipt) {
+    logger.info('sendEmailReceipt detected - Email receipts will be sent.');
+  }
+  if (skipWaitingPeriod) {
+    logger.info('skipWaitingPeriod detected - Waiting period will be skipped.');
+  }
+
+  // Validate request IDs
+  if (requestIds.length > 0 && requestIds.length !== requests.length) {
+    const missingRequests = difference(
+      requestIds,
+      requests.map(({ id }) => id),
+    );
+    if (missingRequests.length > 0) {
+      logger.error(
+        colors.red(
+          `Failed to find the following requests by ID: ${missingRequests.join(
+            ',',
+          )}.`,
+        ),
+      );
+      process.exit(1);
+    }
+  }
+
+  // Map over the requests
+  let total = 0;
+  progressBar.start(requests.length, 0);
+  await map(
+    requests,
+    async (request, ind) => {
+      try {
+        // Pull the request identifiers
+        const requestIdentifiers = copyIdentifiers
+          ? await fetchAllRequestIdentifiers(client, {
+              requestId: request.id,
+            })
+          : [];
+
+        // Make the GraphQL request to restart the request
+        const requestResponse = await restartPrivacyRequest(
+          sombra,
+          {
+            ...request,
+            // override silent mode
+            isSilent:
+              !!markSilent && new Date(request.createdAt) < markSilent
+                ? true
+                : request.isSilent,
+          },
+          {
+            requestIdentifiers,
+            skipWaitingPeriod,
+            sendEmailReceipt,
+          },
+        );
+
+        // Cache successful upload
+        const restartedRequests = state.getValue('restartedRequests');
+        restartedRequests.push({
+          id: requestResponse.id,
+          link: requestResponse.link,
+          rowIndex: ind,
+          coreIdentifier: requestResponse.coreIdentifier,
+          attemptedAt: new Date().toISOString(),
+        });
+        state.setValue(restartedRequests, 'restartedRequests');
+      } catch (err) {
+        const msg = `${err.message} - ${JSON.stringify(
+          err.response?.body,
+          null,
+          2,
+        )}`;
+        const clientError = extractClientError(msg);
+
+        const failingRequests = state.getValue('failingRequests');
+        failingRequests.push({
+          id: request.id,
+          link: request.link,
+          rowIndex: ind,
+          coreIdentifier: request.coreIdentifier,
+          attemptedAt: new Date().toISOString(),
+          error: clientError || msg,
+        });
+        state.setValue(failingRequests, 'failingRequests');
+      }
+      total += 1;
+      progressBar.update(total);
+    },
+    { concurrency },
+  );
+
+  progressBar.stop();
+  const t1 = new Date().getTime();
+  const totalTime = t1 - t0;
+
+  // Log completion time
+  logger.info(
+    colors.green(
+      `Completed restarting of requests in "${totalTime / 1000}" seconds.`,
+    ),
+  );
+
+  // Log errors
+  if (state.getValue('failingRequests').length > 0) {
+    logger.error(
+      colors.red(
+        `Encountered "${state.getValue('failingRequests').length}" errors. ` +
+          `See "${cacheFile}" to review the error messages and inputs.`,
+      ),
+    );
+    process.exit(1);
+  }
+}

--- a/src/requests/constants.ts
+++ b/src/requests/constants.ts
@@ -12,6 +12,9 @@ export const NONE = '[NONE]' as const;
 export const BULK_APPLY = '[APPLY VALUE TO ALL ROWS]' as const;
 export const BLANK = '<blank>' as const;
 
+/** These are uploaded at the top level of the request */
+export const IDENTIFIER_BLOCK_LIST = ['email', 'coreIdentifier'];
+
 /**
  * Column names to map
  */
@@ -92,20 +95,26 @@ export const CachedFileState = t.type({
 /** Type override */
 export type CachedFileState = t.TypeOf<typeof CachedFileState>;
 
+/**
+ * Successfully processed request
+ */
+export const SuccessfulRequest = t.type({
+  id: t.string,
+  link: t.string,
+  rowIndex: t.number,
+  coreIdentifier: t.string,
+  attemptedAt: t.string,
+});
+
+/** Type override */
+export type SuccessfulRequest = t.TypeOf<typeof SuccessfulRequest>;
+
 // Cache state
 export const CachedRequestState = t.type({
   /** Set of privacy requests that failed to upload */
   failingRequests: t.array(t.record(t.string, t.any)),
   /** Successfully uploaded requests */
-  successfulRequests: t.array(
-    t.type({
-      id: t.string,
-      link: t.string,
-      rowIndex: t.number,
-      coreIdentifier: t.string,
-      attemptedAt: t.string,
-    }),
-  ),
+  successfulRequests: t.array(SuccessfulRequest),
   /** Duplicate requests */
   duplicateRequests: t.array(
     t.type({

--- a/src/requests/index.ts
+++ b/src/requests/index.ts
@@ -14,3 +14,5 @@ export * from './mapColumnsToIdentifiers';
 export * from './mapColumnsToAttributes';
 export * from './extractClientError';
 export * from './uploadPrivacyRequestsFromCsv';
+export * from './bulkRestartRequests';
+export * from './restartPrivacyRequest';

--- a/src/requests/mapColumnsToIdentifiers.ts
+++ b/src/requests/mapColumnsToIdentifiers.ts
@@ -1,7 +1,7 @@
 import type { GraphQLClient } from 'graphql-request';
 import inquirer from 'inquirer';
 import { INITIALIZER, makeGraphQLRequest, Initializer } from '../graphql';
-import { CachedFileState } from './constants';
+import { CachedFileState, IDENTIFIER_BLOCK_LIST } from './constants';
 import { fuzzyMatchColumns } from './fuzzyMatchColumns';
 import type { PersistedState } from '@transcend-io/persisted-state';
 
@@ -11,9 +11,6 @@ import type { PersistedState } from '@transcend-io/persisted-state';
 export type IdentifierNameMap = {
   [k in string]: string;
 };
-
-/** These are uploaded at the top level of the request */
-const IDENTIFIER_BLOCK_LIST = ['email', 'coreIdentifier'];
 
 /**
  * Create a mapping from the identifier names that can be included

--- a/src/requests/restartPrivacyRequest.ts
+++ b/src/requests/restartPrivacyRequest.ts
@@ -1,0 +1,94 @@
+import * as t from 'io-ts';
+import groupBy from 'lodash/groupBy';
+import { apply, decodeCodec } from '@transcend-io/type-utils';
+import { IdentifierType } from '@transcend-io/privacy-types';
+import type { Got } from 'got';
+import { PrivacyRequest, RequestIdentifier } from '../graphql';
+import { IDENTIFIER_BLOCK_LIST } from './constants';
+import { PrivacyRequestResponse } from './submitPrivacyRequest';
+
+/**
+ * Restart a privacy request to the Transcend API
+ *
+ * @param sombra - Sombra instance configured to make requests
+ * @param request - Request to restart
+ * @param input - Request input
+ * @returns Successfully submitted request
+ */
+export async function restartPrivacyRequest(
+  sombra: Got,
+  request: PrivacyRequest,
+  {
+    sendEmailReceipt = false,
+    skipWaitingPeriod = false,
+    requestIdentifiers = [],
+  }: {
+    /** List of request identifiers to include */
+    requestIdentifiers?: RequestIdentifier[];
+    /** When true, send an email receipt to data subject */
+    sendEmailReceipt?: boolean;
+    /** Whether to skip waiting period */
+    skipWaitingPeriod?: boolean;
+  } = {},
+): Promise<PrivacyRequestResponse> {
+  // Make the GraphQL request
+  const response = await sombra
+    .post('v1/data-subject-request', {
+      json: {
+        type: request.type,
+        subject: {
+          coreIdentifier: request.coreIdentifier,
+          email: request.email,
+          emailIsVerified: true,
+          ...(requestIdentifiers.length > 0
+            ? {
+                attestedExtraIdentifiers: apply(
+                  groupBy(
+                    requestIdentifiers
+                      .filter(
+                        (ri) =>
+                          // these are already submitted above
+                          !(
+                            ri.name === 'email' && ri.value === request.email
+                          ) && !IDENTIFIER_BLOCK_LIST.includes(ri.name),
+                      )
+                      .map((ri) => ({
+                        ...ri,
+                        type: Object.values(IdentifierType).includes(
+                          ri.name as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+                        )
+                          ? ri.name
+                          : IdentifierType.Custom,
+                      })),
+                    'type',
+                  ),
+                  (values, type) =>
+                    values.map(({ name, value }) => ({
+                      ...(type === IdentifierType.Custom ? { name } : {}),
+                      value,
+                    })),
+                ),
+              }
+            : {}),
+        },
+        requestId: request.id,
+        subjectType: request.subjectType,
+        isSilent: request.isSilent,
+        isTest: request.isTest,
+        locale: request.locale,
+        skipWaitingPeriod,
+        createdAt: request.createdAt,
+        details: `Restarted by Transcend cli: "tr-request-restart" - ${request.details}`,
+        skipSendingReceipt: !sendEmailReceipt,
+      },
+    })
+    .json();
+
+  const { request: requestResponse } = decodeCodec(
+    t.type({
+      request: PrivacyRequestResponse,
+    }),
+    response,
+  );
+  return requestResponse;
+}

--- a/src/requests/uploadPrivacyRequestsFromCsv.ts
+++ b/src/requests/uploadPrivacyRequestsFromCsv.ts
@@ -34,7 +34,7 @@ export async function uploadPrivacyRequestsFromCsv({
   file,
   auth,
   sombraAuth,
-  concurrency = 20,
+  concurrency = 100,
   defaultPhoneCountryCode = '1', // USA
   transcendUrl = 'https://api.transcend.io',
   attributes = [],


### PR DESCRIPTION
## Related Issues

- links https://transcend.height.app/T-8986

This PR moves out our internal battle tested bulk-restart request script to be accessible through the cli.

https://user-images.githubusercontent.com/10264973/205861047-753836ac-1996-457f-ab65-65b9f0f5d3a2.mov


Bulk update a set of privacy requests based on a set of request filters.

#### Authentication

In order to use this cli, you will first need to generate an API key on the Transcend Admin Dashboard (https://app.transcend.io/infrastructure/api-keys).

The API key needs the following scopes:

- Submit New Data Subject Request
- View the Request Compilation

#### Arguments

| Argument             | Description                                                                                                                               | Type            | Default                           | Required |
| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | --------------- | --------------------------------- | -------- |
| auth                 | The Transcend API capable of submitting privacy requests.                                                                                 | string          | N/A                               | true     |
| acions               | The [request action](https://docs.transcend.io/docs/privacy-requests/configuring-requests/data-subject-requests#data-actions) to restart. | RequestAction[] | N/A                               | true     |
| statuses             | The [request statuses](https://docs.transcend.io/docs/privacy-requests/overview#request-statuses) to restart.                             | RequestStatus[] | N/A                               | true     |
| transcendUrl         | URL of the Transcend backend. Use https://api.us.transcend.io for US hosting.                                                             | string - URL    | https://api.transcend.io          | false    |
| requestReceiptFolder | The path to the folder where receipts of each upload are stored. This allows for debugging of errors.                                     | string          | ./privacy-request-upload-receipts | false    |
| sombraAuth           | The sombra internal key, use for additional authentication when self-hosting sombra.                                                      | string          | N/A                               | false    |
| concurrency          | The concurrency to use when uploading requests in parallel.                                                                               | number          | 20                                | false    |
| requestIds           | Specify the specific request IDs to restart                                                                                               | string[]        | []                                | false    |
| createdAt            | Restart requests that were submitted before a specific date.                                                                              | Date            | Date.now()                        | false    |
| markSilent           | Requests older than this date should be marked as silent mode                                                                             | Date            | Date.now() - 3 months             | false    |
| sendEmailReceipt     | Send email receipts to the restarted requests                                                                                             | boolean         | false                             | false    |
| copyIdentifiers      | Copy over all enriched identifiers from the initial request. Leave false to restart from scratch with initial identifiers only.           | boolean         | false                             | false    |
| skipWaitingPeriod    | Skip queued state of request and go straight to compiling                                                                                 | boolean         | false                             | false    |

### Usage

```sh
yarn tr-request-restart --auth=$TRANSCEND_API_KEY --statuses=COMPILING,ENRICHING --actions=ACCESS,ERASURE
```

For self-hosted sombras that use an internal key:

```sh
yarn tr-request-restart --auth=$TRANSCEND_API_KEY --sombraAuth=$SOMBRA_INTERNAL_KEY --statuses=COMPILING,ENRICHING --actions=ACCESS,ERASURE
```

Specifying the backend URL, needed for US hosted backend infrastructure.

```sh
yarn tr-request-restart --auth=$TRANSCEND_API_KEY --sombraAuth=$SOMBRA_INTERNAL_KEY --statuses=COMPILING,ENRICHING --actions=ACCESS,ERASURE \
 --transcendUrl=https://api.us.transcend.io
```

Increase the concurrency (defaults to 20)

```sh
yarn tr-request-restart --auth=$TRANSCEND_API_KEY --statuses=COMPILING,ENRICHING --actions=ACCESS,ERASURE --concurrency=100
```

Restart specific requests by ID

```sh
yarn tr-request-restart --auth=$TRANSCEND_API_KEY --statuses=COMPILING,ENRICHING --actions=ACCESS,ERASURE --requestIds=c3ae78c9-2768-4666-991a-d2f729503337,342e4bd1-64ea-4af0-a4ad-704b5a07cfe4
```

Restart requests that were submitted before a specific date.

```sh
yarn tr-request-restart --auth=$TRANSCEND_API_KEY --statuses=COMPILING,ENRICHING --actions=ACCESS,ERASURE --createdAt=2022-05-11T00:46
```

Restart requests and place everything in silent mode submitted before a certain date

```sh
yarn tr-request-restart --auth=$TRANSCEND_API_KEY --statuses=COMPILING,ENRICHING --actions=ACCESS,ERASURE --markSilent=2022-12-05T00:46
```

Send email receipts to the restarted requests

```sh
yarn tr-request-restart --auth=$TRANSCEND_API_KEY --statuses=COMPILING,ENRICHING --actions=ACCESS,ERASURE --sendEmailReceipt=true
```

Copy over all enriched identifiers from the initial request. Leave false to restart from scratch with initial identifiers only

```sh
yarn tr-request-restart --auth=$TRANSCEND_API_KEY --statuses=COMPILING,ENRICHING --actions=ACCESS,ERASURE --copyIdentifiers=true
```

Skip queued state of request and go straight to compiling

```sh
yarn tr-request-restart --auth=$TRANSCEND_API_KEY --statuses=COMPILING,ENRICHING --actions=ACCESS,ERASURE --skipWaitingPeriod=true
```
