### PR TITLE
Adds support for single attributes on sub-datapoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/cli",
   "description": "Small package containing useful typescript utilities.",
-  "version": "4.20.1",
+  "version": "4.21.0",
   "homepage": "https://github.com/transcend-io/cli",
   "repository": {
     "type": "git",

--- a/src/graphql/syncDataSilos.ts
+++ b/src/graphql/syncDataSilos.ts
@@ -705,13 +705,21 @@ export async function syncDataSilo(
         logger.info(colors.magenta(`Syncing datapoint "${datapoint.key}"...`));
         const fields = datapoint.fields
           ? datapoint.fields.map(
-              ({ key, description, categories, purposes, ...rest }) =>
+              ({
+                key,
+                description,
+                categories,
+                purposes,
+                attributes,
+                ...rest
+              }) =>
                 // TODO: Support setting title separately from the 'key/name'
                 ({
                   name: key,
                   description,
                   categories,
                   purposes,
+                  attributes,
                   accessRequestVisibilityEnabled:
                     rest['access-request-visibility-enabled'],
                   erasureRequestRedactionEnabled:


### PR DESCRIPTION
Subdatapoints were not syncing in attributes correctly. This fixes 1 or 2 bugs.

- fixed here is the inclusion of the attributes in the GraphQL query
- separately, the GraphQL query is not respecting the attributes field, that will need updating on the backend