### PR TITLE
Ability to restart requests with unverified email

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,13 +577,14 @@ The API key needs the following scopes:
 | Argument             | Description                                                                                                                               | Type            | Default                           | Required |
 | -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | --------------- | --------------------------------- | -------- |
 | auth                 | The Transcend API capable of submitting privacy requests.                                                                                 | string          | N/A                               | true     |
-| acions               | The [request action](https://docs.transcend.io/docs/privacy-requests/configuring-requests/data-subject-requests#data-actions) to restart. | RequestAction[] | N/A                               | true     |
+| actions              | The [request action](https://docs.transcend.io/docs/privacy-requests/configuring-requests/data-subject-requests#data-actions) to restart. | RequestAction[] | N/A                               | true     |
 | statuses             | The [request statuses](https://docs.transcend.io/docs/privacy-requests/overview#request-statuses) to restart.                             | RequestStatus[] | N/A                               | true     |
 | transcendUrl         | URL of the Transcend backend. Use https://api.us.transcend.io for US hosting.                                                             | string - URL    | https://api.transcend.io          | false    |
 | requestReceiptFolder | The path to the folder where receipts of each upload are stored. This allows for debugging of errors.                                     | string          | ./privacy-request-upload-receipts | false    |
 | sombraAuth           | The sombra internal key, use for additional authentication when self-hosting sombra.                                                      | string          | N/A                               | false    |
 | concurrency          | The concurrency to use when uploading requests in parallel.                                                                               | number          | 20                                | false    |
 | requestIds           | Specify the specific request IDs to restart                                                                                               | string[]        | []                                | false    |
+| emailIsVerified      | Indicate whether the primary email address is verified. Set to false to send a verification email.                                        | boolean         | true                              | false    |
 | createdAt            | Restart requests that were submitted before a specific date.                                                                              | Date            | Date.now()                        | false    |
 | markSilent           | Requests older than this date should be marked as silent mode                                                                             | Date            | Date.now() - 3 months             | false    |
 | sendEmailReceipt     | Send email receipts to the restarted requests                                                                                             | boolean         | false                             | false    |
@@ -613,6 +614,12 @@ Increase the concurrency (defaults to 20)
 
 ```sh
 yarn tr-request-restart --auth=$TRANSCEND_API_KEY --statuses=COMPILING,ENRICHING --actions=ACCESS,ERASURE --concurrency=100
+```
+
+Re-verify emails
+
+```sh
+yarn tr-request-restart --auth=$TRANSCEND_API_KEY --statuses=COMPILING,ENRICHING --actions=ACCESS,ERASURE --emailIsVerified=false
 ```
 
 Restart specific requests by ID

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/cli",
   "description": "Small package containing useful typescript utilities.",
-  "version": "4.21.0",
+  "version": "4.22.0",
   "homepage": "https://github.com/transcend-io/cli",
   "repository": {
     "type": "git",

--- a/src/cli-request-restart.ts
+++ b/src/cli-request-restart.ts
@@ -46,6 +46,8 @@ async function main(): Promise<void> {
     sendEmailReceipt = 'false',
     /** Copy over all identifiers rather than restarting the request only with the core identifier */
     copyIdentifiers = 'false',
+    /** Whether to restart request with verified email or not */
+    emailIsVerified = 'true',
     /** Skip the waiting period when restarting requests */
     skipWaitingPeriod = 'false',
     /** Include a receipt of the requests that were restarted in this file */
@@ -115,6 +117,7 @@ async function main(): Promise<void> {
     requestStatuses,
     requestIds: splitCsvToList(requestIds),
     createdAt: new Date(createdAt),
+    emailIsVerified: emailIsVerified === 'true',
     markSilent: new Date(markSilent),
     sendEmailReceipt: sendEmailReceipt === 'true',
     copyIdentifiers: copyIdentifiers === 'true',

--- a/src/requests/bulkRestartRequests.ts
+++ b/src/requests/bulkRestartRequests.ts
@@ -50,6 +50,7 @@ export async function bulkRestartRequests({
   createdAt = new Date(),
   markSilent,
   sendEmailReceipt = false,
+  emailIsVerified = true,
   copyIdentifiers = false,
   skipWaitingPeriod = false,
   concurrency = 20,
@@ -68,6 +69,8 @@ export async function bulkRestartRequests({
   sombraAuth?: string;
   /** Request IDs to filter for */
   requestIds?: string[];
+  /** Whether to re-verify the email when restarting the request */
+  emailIsVerified?: boolean;
   /** Filter for requests that were submitted before this date */
   createdAt?: Date;
   /** Requests that have been open for this length of time should be marked as silent mode */
@@ -175,6 +178,7 @@ export async function bulkRestartRequests({
             requestIdentifiers,
             skipWaitingPeriod,
             sendEmailReceipt,
+            emailIsVerified,
           },
         );
 

--- a/src/requests/restartPrivacyRequest.ts
+++ b/src/requests/restartPrivacyRequest.ts
@@ -21,12 +21,15 @@ export async function restartPrivacyRequest(
   {
     sendEmailReceipt = false,
     skipWaitingPeriod = false,
+    emailIsVerified = true,
     requestIdentifiers = [],
   }: {
     /** List of request identifiers to include */
     requestIdentifiers?: RequestIdentifier[];
     /** When true, send an email receipt to data subject */
     sendEmailReceipt?: boolean;
+    /** Whether the email is verified */
+    emailIsVerified?: boolean;
     /** Whether to skip waiting period */
     skipWaitingPeriod?: boolean;
   } = {},
@@ -39,7 +42,7 @@ export async function restartPrivacyRequest(
         subject: {
           coreIdentifier: request.coreIdentifier,
           email: request.email,
-          emailIsVerified: true,
+          emailIsVerified,
           ...(requestIdentifiers.length > 0
             ? {
                 attestedExtraIdentifiers: apply(


### PR DESCRIPTION
This makes it possible to restart a request and send a verification email to those requests. 