### PR TITLE
Adds Cli command to bulk-update request data silos as completed

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@
     - [Authentication](#authentication-7)
     - [Arguments](#arguments-7)
   - [Usage](#usage-8)
+  - [tr-mark-request-data-silos-completed](#tr-mark-request-data-silos-completed)
+    - [Authentication](#authentication-8)
+    - [Arguments](#arguments-8)
+  - [Usage](#usage-9)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -836,4 +840,46 @@ With specific concurrency
 
 ```sh
 yarn tr-manual-enrichment-push-identifiers --auth=$TRANSCEND_API_KEY --concurrency=200
+```
+
+### tr-mark-request-data-silos-completed
+
+This command takes in a CSV of Request IDs as well as a Data Silo ID and marks all associated privacy request jobs as completed.
+This command is useful with the "Bulk Response" UI.
+
+#### Authentication
+
+In order to use this cli, you will first need to generate an API key on the Transcend Admin Dashboard (https://app.transcend.io/infrastructure/api-keys).
+
+The API key must have the following scopes:
+
+- "Manage Request Compilation"
+
+#### Arguments
+
+| Argument     | Description                                                                   | Type               | Default                   | Required |
+| ------------ | ----------------------------------------------------------------------------- | ------------------ | ------------------------- | -------- |
+| auth         | The Transcend API capable of pulling the cron identifiers.                    | string             | N/A                       | true     |
+| dataSiloId   | The ID of the data silo to pull in.                                           | string - UUID      | N/A                       | true     |
+| file         | Path to the CSV file where identifiers will be written to.                    | string - file-path | ./request-identifiers.csv | false    |
+| transcendUrl | URL of the Transcend backend. Use https://api.us.transcend.io for US hosting. | string - URL       | https://api.transcend.io  | false    |
+
+### Usage
+
+```sh
+yarn tr-mark-request-data-silos-completed --auth=$TRANSCEND_API_KEY --dataSiloId=70810f2e-cf90-43f6-9776-901a5950599f
+```
+
+Pull to a specific file location
+
+```sh
+yarn tr-mark-request-data-silos-completed --auth=$TRANSCEND_API_KEY --dataSiloId=70810f2e-cf90-43f6-9776-901a5950599f \
+   --file=/Users/transcend/Desktop/test.csv
+```
+
+Specifying the backend URL, needed for US hosted backend infrastructure.
+
+```sh
+yarn tr-mark-request-data-silos-completed --auth=$TRANSCEND_API_KEY --dataSiloId=70810f2e-cf90-43f6-9776-901a5950599f \
+ --transcendUrl=https://api.us.transcend.io
 ```

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/cli",
   "description": "Small package containing useful typescript utilities.",
-  "version": "4.23.1",
+  "version": "4.24.0",
   "homepage": "https://github.com/transcend-io/cli",
   "repository": {
     "type": "git",
@@ -15,6 +15,7 @@
     "tr-cron-pull-identifiers": "./build/cli-cron-pull-identifiers.js",
     "tr-discover-silos": "./build/cli-discover-silos.js",
     "tr-manual-enrichment-pull-identifiers": "./build/cli-manual-enrichment-pull-identifiers.js",
+    "tr-mark-request-data-silos-completed": "./build/cli-mark-request-data-silos-completed.js",
     "tr-pull": "./build/cli-pull.js",
     "tr-push": "./build/cli-push.js",
     "tr-request-restart": "./build/cli-request-restart.js",

--- a/src/cli-mark-request-data-silos-completed.ts
+++ b/src/cli-mark-request-data-silos-completed.ts
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+
+import yargs from 'yargs-parser';
+import colors from 'colors';
+
+import { logger } from './logger';
+import { markRequestDataSiloIdsCompleted } from './cron';
+
+/**
+ * Given a set of Request IDs and a Data Silo ID, mark the RequestDataSilos as completed
+ *
+ * Requires an API key with scope:
+ * - "Manage Request Compilation"
+ *
+ * Dev Usage:
+ * yarn ts-node ./src/mark-request-data-silos-completed..ts --auth=asd123 \
+ *   --dataSiloId=92636cda-b7c6-48c6-b1b1-2df574596cbc \
+ *   --file=/Users/michaelfarrell/Desktop/test.csv
+ *
+ * Standard usage:
+ * yarn tr-mark-request-data-silos-completed. --auth=asd123  \
+ *   --dataSiloId=92636cda-b7c6-48c6-b1b1-2df574596cbc \
+ *   --file=/Users/michaelfarrell/Desktop/test.csv
+ */
+async function main(): Promise<void> {
+  // Parse command line arguments
+  const {
+    file = './request-identifiers.csv',
+    transcendUrl = 'https://api.transcend.io',
+    auth,
+    dataSiloId,
+  } = yargs(process.argv.slice(2)) as { [k in string]: string };
+
+  // Ensure auth is passed
+  if (!auth) {
+    logger.error(
+      colors.red(
+        'A Transcend API key must be provided. You can specify using --auth=asd123',
+      ),
+    );
+    process.exit(1);
+  }
+
+  // Upload privacy requests
+  await markRequestDataSiloIdsCompleted({
+    file,
+    transcendUrl,
+    auth,
+    dataSiloId,
+  });
+}
+
+main();

--- a/src/cron/index.ts
+++ b/src/cron/index.ts
@@ -3,3 +3,4 @@ export * from './pullCronPageOfIdentifiers';
 export * from './writeCsv';
 export * from './pushCronIdentifiersFromCsv';
 export * from './markCronIdentifierCompleted';
+export * from './markRequestDataSiloIdsCompleted';

--- a/src/cron/markRequestDataSiloIdsCompleted.ts
+++ b/src/cron/markRequestDataSiloIdsCompleted.ts
@@ -1,0 +1,98 @@
+import { map } from 'bluebird';
+import colors from 'colors';
+import { logger } from '../logger';
+import { readCsv } from '../requests';
+import {
+  CHANGE_REQUEST_DATA_SILO_STATUS,
+  fetchRequestDataSilo,
+  makeGraphQLRequest,
+  buildTranscendGraphQLClient,
+} from '../graphql';
+import * as t from 'io-ts';
+import cliProgress from 'cli-progress';
+
+const RequestIdRow = t.type({
+  'Request Id': t.string,
+});
+
+/**
+ * Given a CSV of Request IDs, mark associated RequestDataSilos as completed
+ *
+ * @param options - Options
+ * @returns Number of items marked as completed
+ */
+export async function markRequestDataSiloIdsCompleted({
+  file,
+  dataSiloId,
+  auth,
+  concurrency = 100,
+  transcendUrl = 'https://api.transcend.io',
+}: {
+  /** CSV file path */
+  file: string;
+  /** Transcend API key authentication */
+  auth: string;
+  /** Data Silo ID to pull down jobs for */
+  dataSiloId: string;
+  /** Upload concurrency */
+  concurrency?: number;
+  /** API URL for Transcend backend */
+  transcendUrl?: string;
+}): Promise<number> {
+  // Find all requests made before createdAt that are in a removing data state
+  const client = buildTranscendGraphQLClient(transcendUrl, auth);
+
+  // Time duration
+  const t0 = new Date().getTime();
+  // create a new progress bar instance and use shades_classic theme
+  const progressBar = new cliProgress.SingleBar(
+    {},
+    cliProgress.Presets.shades_classic,
+  );
+
+  // Read from CSV
+  logger.info(colors.magenta(`Reading "${file}" from disk`));
+  const activeResults = readCsv(file, RequestIdRow);
+
+  // Notify Transcend
+  logger.info(
+    colors.magenta(
+      `Notifying Transcend for data silo "${dataSiloId}" marking "${activeResults.length}" requests as completed.`,
+    ),
+  );
+
+  let total = 0;
+  progressBar.start(activeResults.length, 0);
+  await map(
+    activeResults,
+    async (identifier) => {
+      const requestDataSilo = await fetchRequestDataSilo(client, {
+        requestId: identifier['Request Id'],
+        dataSiloId,
+      });
+
+      await makeGraphQLRequest<{
+        /** Whether we successfully uploaded the results */
+        success: boolean;
+      }>(client, CHANGE_REQUEST_DATA_SILO_STATUS, {
+        requestDataSiloId: requestDataSilo.id,
+        status: 'RESOLVED',
+      });
+
+      total += 1;
+      progressBar.update(total);
+    },
+    { concurrency },
+  );
+
+  progressBar.stop();
+  const t1 = new Date().getTime();
+  const totalTime = t1 - t0;
+
+  logger.info(
+    colors.green(
+      `Successfully notified Transcend in "${totalTime / 1000}" seconds!`,
+    ),
+  );
+  return activeResults.length;
+}

--- a/src/graphql/fetchRequestDataSilo.ts
+++ b/src/graphql/fetchRequestDataSilo.ts
@@ -1,0 +1,42 @@
+import { GraphQLClient } from 'graphql-request';
+import { REQUEST_DATA_SILOS } from './gqls';
+import { makeGraphQLRequest } from './makeGraphQLRequest';
+
+export interface RequestDataSilo {
+  /** ID of RequestDataSilo */
+  id: string;
+}
+
+/**
+ * Fetch all request identifiers for a particular request
+ *
+ * @param client - GraphQL client
+ * @param options - Filter options
+ * @returns List of request identifiers
+ */
+export async function fetchRequestDataSilo(
+  client: GraphQLClient,
+  {
+    requestId,
+    dataSiloId,
+  }: {
+    /** ID of request to filter on */
+    requestId: string;
+    /** Data silo ID */
+    dataSiloId: string;
+  },
+): Promise<RequestDataSilo> {
+  const {
+    requestDataSilos: { nodes },
+  } = await makeGraphQLRequest(client, REQUEST_DATA_SILOS, {
+    dataSiloId,
+    requestId,
+  });
+  if (nodes.length !== 1) {
+    throw new Error(
+      `Failed to find RequestDataSilo with requestId:${requestId},dataSiloId:${dataSiloId}`,
+    );
+  }
+
+  return nodes[0];
+}

--- a/src/graphql/gqls/RequestDataSilo.ts
+++ b/src/graphql/gqls/RequestDataSilo.ts
@@ -1,0 +1,28 @@
+import { gql } from 'graphql-request';
+
+export const REQUEST_DATA_SILOS = gql`
+  query TranscendCliRequestDataSilos($requestId: ID!, $dataSiloId: ID!) {
+    requestDataSilos(
+      filterBy: { requestId: $requestId, dataSiloId: $dataSiloId }
+    ) {
+      nodes {
+        id
+      }
+    }
+  }
+`;
+
+export const CHANGE_REQUEST_DATA_SILO_STATUS = gql`
+  mutation TranscendCliMarkRequestDataSiloCompleted(
+    $requestDataSiloId: ID!
+    $status: UpdateRequestDataSiloStatus!
+  ) {
+    changeRequestDataSiloStatus(
+      input: { id: $requestDataSiloId, status: $status }
+    ) {
+      requestDataSilo {
+        id
+      }
+    }
+  }
+`;

--- a/src/graphql/gqls/index.ts
+++ b/src/graphql/gqls/index.ts
@@ -11,3 +11,4 @@ export * from './attributeKey';
 export * from './request';
 export * from './RequestIdentifier';
 export * from './RequestEnricher';
+export * from './RequestDataSilo';

--- a/src/graphql/index.ts
+++ b/src/graphql/index.ts
@@ -16,3 +16,4 @@ export * from './fetchAllAttributeKeys';
 export * from './fetchAllRequests';
 export * from './fetchAllRequestIdentifiers';
 export * from './fetchAllRequestEnrichers';
+export * from './fetchRequestDataSilo';

--- a/yarn.lock
+++ b/yarn.lock
@@ -431,6 +431,7 @@ __metadata:
     tr-cron-pull-identifiers: ./build/cli-cron-pull-identifiers.js
     tr-discover-silos: ./build/cli-discover-silos.js
     tr-manual-enrichment-pull-identifiers: ./build/cli-manual-enrichment-pull-identifiers.js
+    tr-mark-request-data-silos-completed: ./build/cli-mark-request-data-silos-completed.js
     tr-pull: ./build/cli-pull.js
     tr-push: ./build/cli-push.js
     tr-request-restart: ./build/cli-request-restart.js


### PR DESCRIPTION
## Related Issues

- closes https://transcend.height.app/T-21283

User story:

- customer has a lot  of requests (e.g. 1k+) in bulk respond UI
- customer exports all requests to CSV
- customer process a portion of those requests manually
- customer wants to mark only those requests as completed

