### PR TITLE
New cli command `tr-retry-request-data-silos` allows for "wipe and retry" across a set of privacy requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@
     - [Authentication](#authentication-9)
     - [Arguments](#arguments-9)
   - [Usage](#usage-10)
+  - [tr-retry-request-data-silos](#tr-retry-request-data-silos)
+    - [Authentication](#authentication-10)
+    - [Arguments](#arguments-10)
+  - [Usage](#usage-11)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -948,5 +952,39 @@ Specifying the backend URL, needed for US hosted backend infrastructure.
 
 ```sh
 yarn tr-mark-request-data-silos-completed --auth=$TRANSCEND_API_KEY --dataSiloId=70810f2e-cf90-43f6-9776-901a5950599f \
+ --transcendUrl=https://api.us.transcend.io
+```
+
+### tr-retry-request-data-silos
+
+This command allows for bulk restarting a set of data silos jobs for open privacy requests. This is equivalent to clicking the "Wipe and Retry" button for a particular data silo across a set of privacy requests.
+
+#### Authentication
+
+In order to use this cli, you will first need to generate an API key on the Transcend Admin Dashboard (https://app.transcend.io/infrastructure/api-keys).
+
+The API key must have the following scopes:
+
+- "Manage Request Compilation"
+
+#### Arguments
+
+| Argument     | Description                                                                                                                               | Type            | Default                  | Required |
+| ------------ | ----------------------------------------------------------------------------------------------------------------------------------------- | --------------- | ------------------------ | -------- |
+| auth         | The Transcend API capable of pulling the cron identifiers.                                                                                | string          | N/A                      | true     |
+| dataSiloId   | The ID of the data silo to pull in.                                                                                                       | string - UUID   | N/A                      | true     |
+| actions      | The [request action](https://docs.transcend.io/docs/privacy-requests/configuring-requests/data-subject-requests#data-actions) to restart. | RequestAction[] | N/A                      | true     |
+| transcendUrl | URL of the Transcend backend. Use https://api.us.transcend.io for US hosting.                                                             | string - URL    | https://api.transcend.io | false    |
+
+### Usage
+
+```sh
+yarn tr-retry-request-data-silos --auth=$TRANSCEND_API_KEY --dataSiloId=70810f2e-cf90-43f6-9776-901a5950599f --actions=ACCESS
+```
+
+Specifying the backend URL, needed for US hosted backend infrastructure.
+
+```sh
+yarn tr-retry-request-data-silos --auth=$TRANSCEND_API_KEY --dataSiloId=70810f2e-cf90-43f6-9776-901a5950599f --actions=ACCESS \
  --transcendUrl=https://api.us.transcend.io
 ```

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/cli",
   "description": "Small package containing useful typescript utilities.",
-  "version": "4.25.5",
+  "version": "4.26.0",
   "homepage": "https://github.com/transcend-io/cli",
   "repository": {
     "type": "git",
@@ -20,7 +20,8 @@
     "tr-pull": "./build/cli-pull.js",
     "tr-push": "./build/cli-push.js",
     "tr-request-restart": "./build/cli-request-restart.js",
-    "tr-request-upload": "./build/cli-request-upload.js"
+    "tr-request-upload": "./build/cli-request-upload.js",
+    "tr-retry-request-data-silos": "./build/cli-retry-request-data-silos.js"
   },
   "files": [
     "build/**/*",

--- a/src/cli-mark-request-data-silos-completed.ts
+++ b/src/cli-mark-request-data-silos-completed.ts
@@ -13,12 +13,12 @@ import { markRequestDataSiloIdsCompleted } from './cron';
  * - "Manage Request Compilation"
  *
  * Dev Usage:
- * yarn ts-node ./src/mark-request-data-silos-completed..ts --auth=asd123 \
+ * yarn ts-node ./src/cli-mark-request-data-silos-completed.ts --auth=asd123 \
  *   --dataSiloId=92636cda-b7c6-48c6-b1b1-2df574596cbc \
  *   --file=/Users/michaelfarrell/Desktop/test.csv
  *
  * Standard usage:
- * yarn tr-mark-request-data-silos-completed. --auth=asd123  \
+ * yarn tr-mark-request-data-silos-completed --auth=asd123  \
  *   --dataSiloId=92636cda-b7c6-48c6-b1b1-2df574596cbc \
  *   --file=/Users/michaelfarrell/Desktop/test.csv
  */

--- a/src/cli-retry-request-data-silos.ts
+++ b/src/cli-retry-request-data-silos.ts
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+
+import yargs from 'yargs-parser';
+import colors from 'colors';
+import { RequestAction } from '@transcend-io/privacy-types';
+
+import { logger } from './logger';
+import { retryRequestDataSilos } from './requests';
+
+/**
+ * Bulk wipe and retry a set of requests for a specific data silo
+ *
+ * Requires an API key with scope:
+ * - "Manage Request Compilation"
+ *
+ * Dev Usage:
+ * yarn ts-node ./src/cli-retry-request-data-silos.ts --auth=asd123 \
+ *   --dataSiloId=92636cda-b7c6-48c6-b1b1-2df574596cbc \
+ *   --actions=ACCESS,ERASURE
+ *
+ * Standard usage:
+ * yarn tr-retry-request-data-silos --auth=asd123  \
+ *   --dataSiloId=92636cda-b7c6-48c6-b1b1-2df574596cbc \
+ *   --actions=ACCESS,ERASURE
+ */
+async function main(): Promise<void> {
+  // Parse command line arguments
+  const {
+    transcendUrl = 'https://api.transcend.io',
+    auth,
+    dataSiloId,
+    actions,
+  } = yargs(process.argv.slice(2)) as { [k in string]: string };
+
+  // Ensure auth is passed
+  if (!auth) {
+    logger.error(
+      colors.red(
+        'A Transcend API key must be provided. You can specify using --auth=asd123',
+      ),
+    );
+    process.exit(1);
+  }
+
+  // Parse request actions
+  if (!actions) {
+    logger.error(
+      colors.red(
+        'Missing required parameter "actions". e.g. --actions=ERASURE,ACCESS',
+      ),
+    );
+    process.exit(1);
+  }
+  const requestActions = actions.split(',') as RequestAction[];
+  const invalidActions = requestActions.filter(
+    (action) => !Object.values(RequestAction).includes(action),
+  );
+  if (invalidActions.length > 0) {
+    logger.error(
+      colors.red(
+        `Received invalid action values: "${invalidActions.join(',')}"`,
+      ),
+    );
+    process.exit(1);
+  }
+
+  // Upload privacy requests
+  await retryRequestDataSilos({
+    requestActions,
+    transcendUrl,
+    auth,
+    dataSiloId,
+  });
+}
+
+main();

--- a/src/graphql/gqls/RequestDataSilo.ts
+++ b/src/graphql/gqls/RequestDataSilo.ts
@@ -26,3 +26,13 @@ export const CHANGE_REQUEST_DATA_SILO_STATUS = gql`
     }
   }
 `;
+
+export const RETRY_REQUEST_DATA_SILO_STATUS = gql`
+  mutation TranscendCliRetryRequestDataSilo($requestDataSiloId: ID!) {
+    retryRequestDataSilo(id: $requestDataSiloId) {
+      requestDataSilo {
+        id
+      }
+    }
+  }
+`;

--- a/src/graphql/gqls/RequestDataSilo.ts
+++ b/src/graphql/gqls/RequestDataSilo.ts
@@ -27,7 +27,7 @@ export const CHANGE_REQUEST_DATA_SILO_STATUS = gql`
   }
 `;
 
-export const RETRY_REQUEST_DATA_SILO_STATUS = gql`
+export const RETRY_REQUEST_DATA_SILO = gql`
   mutation TranscendCliRetryRequestDataSilo($requestDataSiloId: ID!) {
     retryRequestDataSilo(id: $requestDataSiloId) {
       requestDataSilo {

--- a/src/requests/index.ts
+++ b/src/requests/index.ts
@@ -16,3 +16,4 @@ export * from './extractClientError';
 export * from './uploadPrivacyRequestsFromCsv';
 export * from './bulkRestartRequests';
 export * from './restartPrivacyRequest';
+export * from './retryRequestDataSilos';

--- a/src/requests/retryRequestDataSilos.ts
+++ b/src/requests/retryRequestDataSilos.ts
@@ -1,0 +1,106 @@
+import { map } from 'bluebird';
+import colors from 'colors';
+import { logger } from '../logger';
+import { RequestAction, RequestStatus } from '@transcend-io/privacy-types';
+import {
+  RETRY_REQUEST_DATA_SILO_STATUS,
+  fetchRequestDataSilo,
+  fetchAllRequests,
+  makeGraphQLRequest,
+  buildTranscendGraphQLClient,
+} from '../graphql';
+import cliProgress from 'cli-progress';
+
+/**
+ * Retry a set of RequestDataSilos
+ *
+ * @param options - Options
+ * @returns Number of items marked as completed
+ */
+export async function retryRequestDataSilos({
+  requestActions,
+  dataSiloId,
+  auth,
+  concurrency = 20,
+  transcendUrl = 'https://api.transcend.io',
+}: {
+  /** The request actions that should be restarted */
+  requestActions: RequestAction[];
+  /** Transcend API key authentication */
+  auth: string;
+  /** Data Silo ID to pull down jobs for */
+  dataSiloId: string;
+  /** Concurrency to upload requests in parallel */
+  concurrency?: number;
+  /** API URL for Transcend backend */
+  transcendUrl?: string;
+}): Promise<number> {
+  // Find all requests made before createdAt that are in a removing data state
+  const client = buildTranscendGraphQLClient(transcendUrl, auth);
+
+  // Time duration
+  const t0 = new Date().getTime();
+  // create a new progress bar instance and use shades_classic theme
+  const progressBar = new cliProgress.SingleBar(
+    {},
+    cliProgress.Presets.shades_classic,
+  );
+
+  // Pull in the requests
+  const allRequests = await fetchAllRequests(client, {
+    actions: requestActions,
+    statuses: [RequestStatus.Compiling, RequestStatus.Approving],
+  });
+
+  // Notify Transcend
+  logger.info(
+    colors.magenta(
+      `Retrying requests for Data Silo: "${dataSiloId}", restarting "${allRequests.length}" requests.`,
+    ),
+  );
+
+  let total = 0;
+  let skipped = 0;
+  progressBar.start(allRequests.length, 0);
+  await map(
+    allRequests,
+    async (requestToRestart) => {
+      try {
+        const requestDataSilo = await fetchRequestDataSilo(client, {
+          requestId: requestToRestart.id,
+          dataSiloId,
+        });
+
+        await makeGraphQLRequest<{
+          /** Whether we successfully uploaded the results */
+          success: boolean;
+        }>(client, RETRY_REQUEST_DATA_SILO_STATUS, {
+          requestDataSiloId: requestDataSilo.id,
+        });
+      } catch (err) {
+        // some requests may not have this data silo connected
+        if (!err.message.includes('Failed to find RequestDataSilo')) {
+          throw err;
+        }
+        skipped += 1;
+      }
+
+      total += 1;
+      progressBar.update(total);
+    },
+    { concurrency },
+  );
+
+  progressBar.stop();
+  const t1 = new Date().getTime();
+  const totalTime = t1 - t0;
+
+  logger.info(
+    colors.green(
+      `Successfully notified Transcend in "${
+        totalTime / 1000
+      }" seconds for ${total} requests, ${skipped} requests were skipped because data silo was not attached to the request!`,
+    ),
+  );
+  return allRequests.length;
+}

--- a/src/requests/retryRequestDataSilos.ts
+++ b/src/requests/retryRequestDataSilos.ts
@@ -3,7 +3,7 @@ import colors from 'colors';
 import { logger } from '../logger';
 import { RequestAction, RequestStatus } from '@transcend-io/privacy-types';
 import {
-  RETRY_REQUEST_DATA_SILO_STATUS,
+  RETRY_REQUEST_DATA_SILO,
   fetchRequestDataSilo,
   fetchAllRequests,
   makeGraphQLRequest,
@@ -74,7 +74,7 @@ export async function retryRequestDataSilos({
         await makeGraphQLRequest<{
           /** Whether we successfully uploaded the results */
           success: boolean;
-        }>(client, RETRY_REQUEST_DATA_SILO_STATUS, {
+        }>(client, RETRY_REQUEST_DATA_SILO, {
           requestDataSiloId: requestDataSilo.id,
         });
       } catch (err) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -437,6 +437,7 @@ __metadata:
     tr-push: ./build/cli-push.js
     tr-request-restart: ./build/cli-request-restart.js
     tr-request-upload: ./build/cli-request-upload.js
+    tr-retry-request-data-silos: ./build/cli-retry-request-data-silos.js
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
### tr-retry-request-data-silos

This command allows for bulk restarting a set of data silos jobs for open privacy requests. This is equivalent to clicking the "Wipe and Retry" button for a particular data silo across a set of privacy requests.

#### Authentication

In order to use this cli, you will first need to generate an API key on the Transcend Admin Dashboard (https://app.transcend.io/infrastructure/api-keys).

The API key must have the following scopes:

- "Manage Request Compilation"

#### Arguments

| Argument     | Description                                                                                                                               | Type            | Default                  | Required |
| ------------ | ----------------------------------------------------------------------------------------------------------------------------------------- | --------------- | ------------------------ | -------- |
| auth         | The Transcend API capable of pulling the cron identifiers.                                                                                | string          | N/A                      | true     |
| dataSiloId   | The ID of the data silo to pull in.                                                                                                       | string - UUID   | N/A                      | true     |
| actions      | The [request action](https://docs.transcend.io/docs/privacy-requests/configuring-requests/data-subject-requests#data-actions) to restart. | RequestAction[] | N/A                      | true     |
| transcendUrl | URL of the Transcend backend. Use https://api.us.transcend.io for US hosting.                                                             | string - URL    | https://api.transcend.io | false    |

### Usage

```sh
yarn tr-retry-request-data-silos --auth=$TRANSCEND_API_KEY --dataSiloId=70810f2e-cf90-43f6-9776-901a5950599f --actions=ACCESS
```

Specifying the backend URL, needed for US hosted backend infrastructure.

```sh
yarn tr-retry-request-data-silos --auth=$TRANSCEND_API_KEY --dataSiloId=70810f2e-cf90-43f6-9776-901a5950599f --actions=ACCESS \
 --transcendUrl=https://api.us.transcend.io
```
