### PR TITLE
Remove docs for explicit definition of JSON schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ You can find various examples for your `transcend.yml` file in the [examples/](.
 
 The API for this YAML file can be found in [./src/codecs.ts](./src/codecs.ts) under the variable named "TranscendInput". The shape of the YAML file will be type-checked every time a command is run.
 
-By default, your editor or IDE should recognize `transcend.yml` and lint it against our published JSON schema. This is dependent on whether your editor uses [yaml-language-server](https://github.com/redhat-developer/yaml-language-server)
+By default, your editor or IDE should recognize `transcend.yml` and validate it against our published [JSON schema](./transcend-yml-schema-v4.json). This is dependent on whether your editor uses [yaml-language-server](https://github.com/redhat-developer/yaml-language-server), such as through the [VS Code YAML extension](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml).
 
 The structure of `transcend.yml` looks something like the following:
 

--- a/README.md
+++ b/README.md
@@ -124,17 +124,11 @@ You can find various examples for your `transcend.yml` file in the [examples/](.
 
 The API for this YAML file can be found in [./src/codecs.ts](./src/codecs.ts) under the variable named "TranscendInput". The shape of the YAML file will be type-checked every time a command is run.
 
-You can include a JSON schema to check `transcend.yml` in your IDE by adding this comment to the top of your file:
-
-```yml
-# yaml-language-server: $schema=https://raw.githubusercontent.com/transcend-io/cli/main/transcend-yml-schema-v4.json
-```
+By default, your editor or IDE should recognize `transcend.yml` and lint it against our published JSON schema. This is dependent on whether your editor uses [yaml-language-server](https://github.com/redhat-developer/yaml-language-server)
 
 The structure of `transcend.yml` looks something like the following:
 
 ```yaml
-# yaml-language-server: $schema=https://raw.githubusercontent.com/transcend-io/cli/main/transcend-yml-schema-v4.json
-
 # Manage at: https://app.transcend.io/infrastructure/api-keys
 # See https://docs.transcend.io/docs/authentication
 # Define API keys that may be shared across data silos


### PR DESCRIPTION
This is now published and editors/IDEs will automatically recognize `transcend.yml` https://github.com/SchemaStore/schemastore/pull/2823

## Related Issues

- _[none]_

## Security Implications

_[none]_

## System Availability

_[none]_
