### PR TITLE
Manage consent manager domain list via cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,12 @@ Pull in attribute definitions only (see [this example](./examples/attributes.yml
 tr-pull --auth=$TRANSCEND_API_KEY --resources=attributes
 ```
 
+Pull in consent manager domain list (see [this example](./examples/consent-manager-domains.yml)):
+
+```sh
+tr-pull --auth=$TRANSCEND_API_KEY --resources=consentManager
+```
+
 Pull everything:
 
 ```sh

--- a/examples/consent-manager-domains.yml
+++ b/examples/consent-manager-domains.yml
@@ -1,0 +1,4 @@
+consent-manager:
+  domains:
+    - test.transcend.io
+    - docs.transcend.io

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/cli",
   "description": "Small package containing useful typescript utilities.",
-  "version": "4.29.0",
+  "version": "4.30.0",
   "homepage": "https://github.com/transcend-io/cli",
   "repository": {
     "type": "git",

--- a/src/graphql/gqls/consentManager.ts
+++ b/src/graphql/gqls/consentManager.ts
@@ -154,3 +154,16 @@ export const FETCH_CONSENT_MANAGER = gql`
     }
   }
 `;
+
+export const UPDATE_CONSENT_MANAGER_DOMAINS = gql`
+  mutation TranscendCliUpdateConsentManagerDomains(
+    $airgapBundleId: ID!
+    $domains: [String!]!
+  ) {
+    updateConsentManagerDomains(
+      input: { id: $airgapBundleId, domains: $domains }
+    ) {
+      clientMutationId
+    }
+  }
+`;

--- a/src/graphql/index.ts
+++ b/src/graphql/index.ts
@@ -24,4 +24,5 @@ export * from './fetchAllCookies';
 export * from './fetchConsentManagerId';
 export * from './fetchAllBusinessEntities';
 export * from './syncDataFlows';
+export * from './syncConsentManager';
 export * from './fetchAllActions';

--- a/src/graphql/syncConfigurationToTranscend.ts
+++ b/src/graphql/syncConfigurationToTranscend.ts
@@ -9,6 +9,7 @@ import { syncAttribute } from './syncAttribute';
 import { syncDataSilo, DataSilo } from './syncDataSilos';
 import { ensureAllDataSubjectsExist } from './fetchDataSubjects';
 import { fetchApiKeys } from './fetchApiKeys';
+import { syncConsentManager } from './syncConsentManager';
 import { fetchAllAttributes } from './fetchAllAttributes';
 import { UPDATE_DATA_SILO } from './gqls';
 import { fetchAllDataFlows } from './fetchAllDataFlows';
@@ -43,7 +44,7 @@ export async function syncConfigurationToTranscend(
     // actions, // FIXME
     // identifiers, // FIXME
     // cookies, // FIXME
-    // consentManager, // FIXME
+    'consent-manager': consentManager,
     'data-silos': dataSilos,
     'data-flows': dataFlows,
   } = input;
@@ -59,6 +60,20 @@ export async function syncConfigurationToTranscend(
       // Grab API keys
       dataSilos ? fetchApiKeys(input, client) : {},
     ]);
+
+  // Sync consent manager
+  if (consentManager) {
+    logger.info(colors.magenta('Syncing consent manager...'));
+    try {
+      await syncConsentManager(client, consentManager);
+      logger.info(colors.green('Successfully synced consent manager!'));
+    } catch (err) {
+      encounteredError = true;
+      logger.info(
+        colors.red(`Failed to sync consent manager! - ${err.message}`),
+      );
+    }
+  }
 
   // Sync email templates
   if (templates) {

--- a/src/graphql/syncConsentManager.ts
+++ b/src/graphql/syncConsentManager.ts
@@ -1,0 +1,24 @@
+import { ConsentManagerInput } from '../codecs';
+import { GraphQLClient } from 'graphql-request';
+import { UPDATE_CONSENT_MANAGER_DOMAINS } from './gqls';
+import { makeGraphQLRequest } from './makeGraphQLRequest';
+import { fetchConsentManagerId } from './fetchConsentManagerId';
+
+/**
+ * Sync the consent manager
+ *
+ * @param client - GraphQL client
+ * @param consentManager - The consent manager input
+ */
+export async function syncConsentManager(
+  client: GraphQLClient,
+  consentManager: ConsentManagerInput,
+): Promise<void> {
+  const airgapBundleId = await fetchConsentManagerId(client);
+  if (consentManager.domains) {
+    await makeGraphQLRequest(client, UPDATE_CONSENT_MANAGER_DOMAINS, {
+      domains: consentManager.domains,
+      airgapBundleId,
+    });
+  }
+}


### PR DESCRIPTION
## Related Issues

- closes https://transcend.height.app/T-21412

## Description

It's now possible to configure domain lists from the cli:

1) `tr-pull --auth=$TRANSCEND_API_KEY --resources=consentManager`
2) Edit yaml:

```yml
consent-manager:
  domains:
    - test.transcend.io
    - docs.transcend.io

```

3) `tr-push --auth=$TRANSCEND_API_KEY`