### PR TITLE
tr-push can push multiple configuration files in a folder into multiple transcend instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,13 +416,23 @@ An alternative file destination can be specified:
 tr-push --auth=$TRANSCEND_API_KEY --file=./custom/location.yml
 ```
 
-Push changes to multiple Transcend instances using the output of [tr-generate-api-keys](#tr-generate-api-keys)
+Push a single yml file configuration into multiple Transcend instances. This uses the output of [tr-generate-api-keys](#tr-generate-api-keys).
 
 ```sh
 tr-generate-api-keys  --email=test@transcend.io --password=$TRANSCEND_PASSWORD \
    --scopes="View Email Templates,View Data Map" --apiKeyTitle="CLI Usage Cross Instance Sync" --file=./transcend-api-keys.json
 tr-pull --auth=$TRANSCEND_API_KEY
 tr-push --auth=./transcend-api-keys.json
+```
+
+Push multiple yml file configurations into multiple Transcend instances. This uses the output of [tr-generate-api-keys](#tr-generate-api-keys).
+
+```sh
+tr-generate-api-keys  --email=test@transcend.io --password=$TRANSCEND_PASSWORD \
+   --scopes="View Email Templates,View Data Map" --apiKeyTitle="CLI Usage Cross Instance Sync" --file=./transcend-api-keys.json
+tr-pull --auth=./transcend-api-keys.json --file=./transcend/
+# <edit yml files in folder in between these steps>
+tr-push --auth=./transcend-api-keys.json --file=./transcend/
 ```
 
 Some things to note about this sync process:

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/cli",
   "description": "Small package containing useful typescript utilities.",
-  "version": "4.40.1",
+  "version": "4.41.0",
   "homepage": "https://github.com/transcend-io/cli",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Push multiple yml file configurations into multiple Transcend instances. This uses the output of [tr-generate-api-keys](#tr-generate-api-keys).

```sh
tr-generate-api-keys  --email=test@transcend.io --password=$TRANSCEND_PASSWORD \
   --scopes="View Email Templates,View Data Map" --apiKeyTitle="CLI Usage Cross Instance Sync" --file=./transcend-api-keys.json
tr-pull --auth=./transcend-api-keys.json --file=./transcend/
# <edit yml files in folder in between these steps>
tr-push --auth=./transcend-api-keys.json --file=./transcend/
```