### PR TITLE
Consent manager sync `uspapi` and `signedIabAgreement` through `tr-push` command

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -65,6 +65,7 @@
     "thlorenz",
     "tsbuildinfo",
     "Upserting",
+    "uspapi",
     "yaml",
     "yarnpkg"
   ]

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/cli",
   "description": "Small package containing useful typescript utilities.",
-  "version": "4.43.0",
+  "version": "4.44.0",
   "homepage": "https://github.com/transcend-io/cli",
   "repository": {
     "type": "git",

--- a/src/graphql/gqls/consentManager.ts
+++ b/src/graphql/gqls/consentManager.ts
@@ -239,3 +239,11 @@ export const UPDATE_CONSENT_MANAGER_PARTITION = gql`
     }
   }
 `;
+
+export const UPDATE_TOGGLE_USP_API = gql`
+  mutation TranscendCliToggleUspAPI($input: ToggleUspapiInput!) {
+    toggleUspapi(input: $input) {
+      clientMutationId
+    }
+  }
+`;

--- a/src/graphql/syncConsentManager.ts
+++ b/src/graphql/syncConsentManager.ts
@@ -4,6 +4,7 @@ import {
   UPDATE_CONSENT_MANAGER_DOMAINS,
   FETCH_PRIVACY_CENTER_ID,
   CREATE_CONSENT_MANAGER,
+  UPDATE_TOGGLE_USP_API,
   UPDATE_CONSENT_MANAGER_PARTITION,
   DEPLOYED_PRIVACY_CENTER_URL,
 } from './gqls';
@@ -81,6 +82,19 @@ export async function syncConsentManager(
     });
   }
 
+  // sync uspapi
+  if (consentManager.uspapi || consentManager.signedIabAgreement) {
+    await makeGraphQLRequest(client, UPDATE_TOGGLE_USP_API, {
+      input: {
+        id: airgapBundleId,
+        ...(consentManager.uspapi ? { uspapi: consentManager.uspapi } : {}),
+        ...(consentManager.signedIabAgreement
+          ? { signedIabAgreement: consentManager.signedIabAgreement }
+          : {}),
+      },
+    });
+  }
+
   // TODO: https://transcend.height.app/T-23920
   //  csp: CspOption;
   //  unknownRequestPolicy: UnknownRequestPolicy;
@@ -91,8 +105,4 @@ export async function syncConsentManager(
   //  syncEndpoint: string;
   // TODO: https://transcend.height.app/T-23919
   //  syncGroups: string;
-
-  // TODO: https://transcend.height.app/T-23872
-  //  signedIabAgreement: SignedIabAgreementOption;
-  //  uspapi: SignedIabAgreementOption;
 }


### PR DESCRIPTION
## Related Issues

- closes https://transcend.height.app/T-23872

Adds ability to sync `uspapi` and `signedIabAgreement` through `tr-push` command