### PR TITLE
Adds the ability to bulk upload data flows from CSV

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ _Note: The scopes for tr-push are comprehensive of the scopes for tr-pull_
 
 | Argument         | Description                                                                              | Type                                                         | Default                               | Required |
 | ---------------- | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------ | ------------------------------------- | -------- |
-| auth             | The Transcend API capable of fetching the configuration                                  | string (API key or path to tr-generate-api-keys JSON output) | N/A                                   | true     |
+| auth             | The Transcend API key with the scopes necessary for the command.                         | string (API key or path to tr-generate-api-keys JSON output) | N/A                                   | true     |
 | resources        | The different resource types to pull in (see table above for breakdown of each resource) | string                                                       | apiKeys,templates,dataSilos,enrichers | false    |
 | file             | Path to the YAML file to pull into                                                       | string - file-path                                           | ./transcend.yml                       | false    |
 | transcendUrl     | URL of the Transcend backend. Use https://api.us.transcend.io for US hosting.            | string - URL                                                 | https://api.transcend.io              | false    |
@@ -422,7 +422,7 @@ The API key needs the following scopes when pushing the various resource types:
 
 | Argument        | Description                                                                                                 | Type                                                         | Default                  | Required |
 | --------------- | ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ | ------------------------ | -------- |
-| auth            | The Transcend API capable of pushing the configuration                                                      | string (API key or path to tr-generate-api-keys JSON output) | N/A                      | true     |
+| auth            | The Transcend API key with the scopes necessary for the command.                                            | string (API key or path to tr-generate-api-keys JSON output) | N/A                      | true     |
 | file            | Path to the YAML file to push from                                                                          | string - file-path                                           | ./transcend.yml          | false    |
 | transcendUrl    | URL of the Transcend backend. Use https://api.us.transcend.io for US hosting.                               | string - URL                                                 | https://api.transcend.io | false    |
 | pageSize        | The page size to use when paginating over the API                                                           | number                                                       | 50                       | false    |
@@ -629,7 +629,7 @@ The API key needs the following scopes:
 
 | Argument                | Description                                                                                                             | Type               | Default                                 | Required |
 | ----------------------- | ----------------------------------------------------------------------------------------------------------------------- | ------------------ | --------------------------------------- | -------- |
-| auth                    | The Transcend API capable of submitting privacy requests.                                                               | string             | N/A                                     | true     |
+| auth                    | The Transcend API key with the scopes necessary for the command.                                                        | string             | N/A                                     | true     |
 | file                    | Path to the CSV file of requests to tupload.                                                                            | string - file-path | ./requests.csv                          | false    |
 | transcendUrl            | URL of the Transcend backend. Use https://api.us.transcend.io for US hosting.                                           | string - URL       | https://api.transcend.io                | false    |
 | cacheFilepath           | The path to the JSON file encoding the metadata used to map the CSV shape to Transcend API.                             | string             | ./transcend-privacy-requests-cache.json | false    |
@@ -737,7 +737,7 @@ The API key needs the following scopes:
 
 | Argument             | Description                                                                                                                               | Type            | Default                           | Required |
 | -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | --------------- | --------------------------------- | -------- |
-| auth                 | The Transcend API capable of submitting privacy requests.                                                                                 | string          | N/A                               | true     |
+| auth                 | The Transcend API key with the scopes necessary for the command.                                                                          | string          | N/A                               | true     |
 | actions              | The [request action](https://docs.transcend.io/docs/privacy-requests/configuring-requests/data-subject-requests#data-actions) to restart. | RequestAction[] | N/A                               | true     |
 | statuses             | The [request statuses](https://docs.transcend.io/docs/privacy-requests/overview#request-statuses) to restart.                             | RequestStatus[] | N/A                               | true     |
 | transcendUrl         | URL of the Transcend backend. Use https://api.us.transcend.io for US hosting.                                                             | string - URL    | https://api.transcend.io          | false    |
@@ -836,7 +836,7 @@ The API key needs the following scopes:
 
 | Argument        | Description                                                                                                                               | Type               | Default                        | Required |
 | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ------------------------------ | -------- |
-| auth            | The Transcend API capable of pulling privacy requests.                                                                                    | string             | N/A                            | true     |
+| auth            | The Transcend API key with the scopes necessary for the command.                                                                          | string             | N/A                            | true     |
 | actions         | The [request action](https://docs.transcend.io/docs/privacy-requests/configuring-requests/data-subject-requests#data-actions) to restart. | RequestAction[]    | N/A                            | false    |
 | statuses        | The [request statuses](https://docs.transcend.io/docs/privacy-requests/overview#request-statuses) to restart.                             | RequestStatus[]    | N/A                            | false    |
 | transcendUrl    | URL of the Transcend backend. Use https://api.us.transcend.io for US hosting.                                                             | string - URL       | https://api.transcend.io       | false    |
@@ -909,7 +909,7 @@ The API key must be associated to the ID of the integration/data silo that is be
 
 | Argument     | Description                                                                                                                             | Type                   | Default                  | Required |
 | ------------ | --------------------------------------------------------------------------------------------------------------------------------------- | ---------------------- | ------------------------ | -------- |
-| auth         | The Transcend API capable of pulling the cron identifiers.                                                                              | string                 | N/A                      | true     |
+| auth         | The Transcend API key with the scopes necessary for the command.                                                                        | string                 | N/A                      | true     |
 | dataSiloId   | The ID of the data silo to pull in.                                                                                                     | string - UUID          | N/A                      | true     |
 | requestType  | The [request action](https://docs.transcend.io/docs/privacy-requests/configuring-requests/data-subject-requests#data-actions) to fetch. | string - RequestAction | N/A                      | true     |
 | file         | Path to the CSV file where identifiers will be written to.                                                                              | string - file-path     | ./cron-identifiers.csv   | false    |
@@ -974,7 +974,7 @@ The API key must be associated to the ID of the integration/data silo that is be
 
 | Argument     | Description                                                                          | Type               | Default                  | Required |
 | ------------ | ------------------------------------------------------------------------------------ | ------------------ | ------------------------ | -------- |
-| auth         | The Transcend API capable of pulling the cron identifiers.                           | string             | N/A                      | true     |
+| auth         | The Transcend API key with the scopes necessary for the command.                     | string             | N/A                      | true     |
 | dataSiloId   | The ID of the data silo to pull in.                                                  | string - UUID      | N/A                      | true     |
 | file         | Path to the CSV file where identifiers will be written to.                           | string - file-path | ./cron-identifiers.csv   | false    |
 | transcendUrl | URL of the Transcend backend. Use https://api.us.transcend.io for US hosting.        | string - URL       | https://api.transcend.io | false    |
@@ -1032,7 +1032,7 @@ The API key must have the following scopes:
 
 | Argument     | Description                                                                   | Type               | Default                             | Required |
 | ------------ | ----------------------------------------------------------------------------- | ------------------ | ----------------------------------- | -------- |
-| auth         | The Transcend API capable of pull request information.                        | string             | N/A                                 | true     |
+| auth         | The Transcend API key with the scopes necessary for the command.              | string             | N/A                                 | true     |
 | transcendUrl | URL of the Transcend backend. Use https://api.us.transcend.io for US hosting. | string - URL       | https://api.transcend.io            | false    |
 | file         | Path to the CSV file where requests will be written to.                       | string - file-path | ./manual-enrichment-identifiers.csv | false    |
 | actions      | The set of request actions to pull requests for.                              | RequestAction[]    | []                                  | false    |
@@ -1092,7 +1092,7 @@ The API key must have the following scopes:
 
 | Argument     | Description                                                                          | Type               | Default                             | Required |
 | ------------ | ------------------------------------------------------------------------------------ | ------------------ | ----------------------------------- | -------- |
-| auth         | The Transcend API capable of pull request information.                               | string             | N/A                                 | true     |
+| auth         | The Transcend API key with the scopes necessary for the command.                     | string             | N/A                                 | true     |
 | enricherId   | The ID of the Request Enricher to upload to                                          | string - UUID      | N/A                                 | true     |
 | sombraAuth   | The sombra internal key, use for additional authentication when self-hosting sombra. | string             | N/A                                 | false    |
 | transcendUrl | URL of the Transcend backend. Use https://api.us.transcend.io for US hosting.        | string - URL       | https://api.transcend.io            | false    |
@@ -1146,7 +1146,7 @@ The API key must have the following scopes:
 
 | Argument     | Description                                                                   | Type               | Default                   | Required |
 | ------------ | ----------------------------------------------------------------------------- | ------------------ | ------------------------- | -------- |
-| auth         | The Transcend API capable of pulling the cron identifiers.                    | string             | N/A                       | true     |
+| auth         | The Transcend API key with the scopes necessary for the command.              | string             | N/A                       | true     |
 | dataSiloId   | The ID of the data silo to pull in.                                           | string - UUID      | N/A                       | true     |
 | file         | Path to the CSV file where identifiers will be written to.                    | string - file-path | ./request-identifiers.csv | false    |
 | transcendUrl | URL of the Transcend backend. Use https://api.us.transcend.io for US hosting. | string - URL       | https://api.transcend.io  | false    |
@@ -1187,7 +1187,7 @@ The API key must have the following scopes:
 
 | Argument     | Description                                                                                                                               | Type            | Default                  | Required |
 | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------- | --------------- | ------------------------ | -------- |
-| auth         | The Transcend API capable of pulling the cron identifiers.                                                                                | string          | N/A                      | true     |
+| auth         | The Transcend API key with the scopes necessary for the command.                                                                          | string          | N/A                      | true     |
 | dataSiloId   | The ID of the data silo to pull in.                                                                                                       | string - UUID   | N/A                      | true     |
 | actions      | The [request action](https://docs.transcend.io/docs/privacy-requests/configuring-requests/data-subject-requests#data-actions) to restart. | RequestAction[] | N/A                      | true     |
 | transcendUrl | URL of the Transcend backend. Use https://api.us.transcend.io for US hosting.                                                             | string - URL    | https://api.transcend.io | false    |
@@ -1221,7 +1221,7 @@ The API key must have the following scopes:
 
 | Argument     | Description                                                                   | Type         | Default                  | Required |
 | ------------ | ----------------------------------------------------------------------------- | ------------ | ------------------------ | -------- |
-| auth         | The Transcend API capable of pulling the cron identifiers.                    | string       | N/A                      | true     |
+| auth         | The Transcend API key with the scopes necessary for the command.              | string       | N/A                      | true     |
 | bundleTypes  | The bundle types to deploy                                                    | BundleType[] | PRODUCTION,TEST          | false    |
 | deploy       | When true, deploy the Consent Manager after updating the version              | boolean      | false                    | false    |
 | transcendUrl | URL of the Transcend backend. Use https://api.us.transcend.io for US hosting. | string - URL | https://api.transcend.io | false    |
@@ -1288,7 +1288,7 @@ The API key must have the following scopes:
 
 | Argument        | Description                                                                                                | Type                 | Default                  | Required |
 | --------------- | ---------------------------------------------------------------------------------------------------------- | -------------------- | ------------------------ | -------- |
-| auth            | The Transcend API capable of pulling the cron identifiers.                                                 | string               | N/A                      | true     |
+| auth            | The Transcend API key with the scopes necessary for the command.                                           | string               | N/A                      | true     |
 | trackerStatus   | Whether or not to upload the data flows into the "Approved" tab (LIVE) or the "Triage" tab (NEEDS_REVIEW). | ConsentTrackerStatus | N/A                      | true     |
 | file            | Path to the CSV file to upload                                                                             | string - file-path   | ./data-flows.csv         | false    |
 | classifyService | When true, automatically assign the service for a data flow based on the domain that is specified          | boolean              | false                    | false    |

--- a/README.md
+++ b/README.md
@@ -57,14 +57,18 @@
     - [Authentication](#authentication-11)
     - [Arguments](#arguments-11)
     - [Usage](#usage-12)
-  - [tr-update-consent-manager](#tr-update-consent-manager)
+  - [tr-upload-data-flows-from-csv](#tr-upload-data-flows-from-csv)
     - [Authentication](#authentication-12)
     - [Arguments](#arguments-12)
     - [Usage](#usage-13)
-  - [tr-generate-api-keys](#tr-generate-api-keys)
+  - [tr-upload-data-flows-from-csv](#tr-upload-data-flows-from-csv-1)
     - [Authentication](#authentication-13)
     - [Arguments](#arguments-13)
     - [Usage](#usage-14)
+  - [tr-generate-api-keys](#tr-generate-api-keys)
+    - [Authentication](#authentication-14)
+    - [Arguments](#arguments-14)
+    - [Usage](#usage-15)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -94,7 +98,7 @@ yarn tr-cron-mark-identifiers-completed --auth=$TRANSCEND_API_KEY
 yarn tr-manual-enrichment-pull-identifiers --auth=$TRANSCEND_API_KEY
 yarn tr-mark-request-data-silos-completed --auth=$TRANSCEND_API_KEY
 yarn tr-retry-request-data-silos --auth=$TRANSCEND_API_KEY
-yarn tr-update-consent-manager --auth=$TRANSCEND_API_KEY
+yarn tr-upload-data-flows-from-csv --auth=$TRANSCEND_API_KEY
 yarn tr-generate-api-keys --auth=$TRANSCEND_API_KEY
 ```
 
@@ -116,7 +120,7 @@ tr-cron-mark-identifiers-completed --auth=$TRANSCEND_API_KEY
 tr-manual-enrichment-pull-identifiers --auth=$TRANSCEND_API_KEY
 tr-mark-request-data-silos-completed --auth=$TRANSCEND_API_KEY
 tr-retry-request-data-silos --auth=$TRANSCEND_API_KEY
-tr-update-consent-manager --auth=$TRANSCEND_API_KEY
+tr-upload-data-flows-from-csv --auth=$TRANSCEND_API_KEY
 tr-generate-api-keys --auth=$TRANSCEND_API_KEY
 ```
 
@@ -423,7 +427,7 @@ The API key needs the following scopes when pushing the various resource types:
 | transcendUrl    | URL of the Transcend backend. Use https://api.us.transcend.io for US hosting.                               | string - URL                                                 | https://api.transcend.io | false    |
 | pageSize        | The page size to use when paginating over the API                                                           | number                                                       | 50                       | false    |
 | variables       | The variables to template into the YAML file when pushing configuration. e.g. domain:acme.com,stage:staging | string                                                       | N/A                      | false    |
-| classifyService | classify data flow service if missing                                                                       | boolean                                                      | false                    | false    |
+| classifyService | When true, automatically assign the service for a data flow based on the domain that is specified           | boolean                                                      | false                    | false    |
 
 #### Usage
 
@@ -1201,7 +1205,7 @@ yarn tr-retry-request-data-silos --auth=$TRANSCEND_API_KEY --dataSiloId=70810f2e
  --transcendUrl=https://api.us.transcend.io
 ```
 
-### tr-update-consent-manager
+### tr-upload-data-flows-from-csv
 
 This command allows for updating Consent Manager to latest version. The consent manager bundle can also be deployed using this commannd.
 
@@ -1219,46 +1223,109 @@ The API key must have the following scopes:
 | ------------ | ----------------------------------------------------------------------------- | ------------ | ------------------------ | -------- |
 | auth         | The Transcend API capable of pulling the cron identifiers.                    | string       | N/A                      | true     |
 | bundleTypes  | The bundle types to deploy                                                    | BundleType[] | PRODUCTION,TEST          | false    |
-| deokiy       | When true, deploy the Consent Manager after updating the version              | boolean      | false                    | false    |
+| deploy       | When true, deploy the Consent Manager after updating the version              | boolean      | false                    | false    |
 | transcendUrl | URL of the Transcend backend. Use https://api.us.transcend.io for US hosting. | string - URL | https://api.transcend.io | false    |
 
 #### Usage
 
 ```sh
-yarn tr-update-consent-manager --auth=$TRANSCEND_API_KEY
+yarn tr-upload-data-flows-from-csv --auth=$TRANSCEND_API_KEY
 ```
 
-Specifying the backend URL, needed for US hosted backend infrastructu re.
+Specifying the backend URL, needed for US hosted backend infrastructure.
 
 ```sh
-yarn tr-update-consent-manager --auth=$TRANSCEND_API_KEY --transcendUrl=https://api.us.transcend.io
+yarn tr-upload-data-flows-from-csv --auth=$TRANSCEND_API_KEY --transcendUrl=https://api.us.transcend.io
 ```
 
 Update version and deploy bundles.
 
 ```sh
-yarn tr-update-consent-manager -auth=$TRANSCEND_API_KEY --deploy=true
+yarn tr-upload-data-flows-from-csv -auth=$TRANSCEND_API_KEY --deploy=true
 ```
 
 Update just the TEST bundle
 
 ```sh
-yarn tr-update-consent-manager --auth=$TRANSCEND_API_KEY --bundleTypes=TEST
+yarn tr-upload-data-flows-from-csv --auth=$TRANSCEND_API_KEY --bundleTypes=TEST
 ```
 
 Update just the PRODUCTION bundle
 
 ```sh
-yarn tr-update-consent-manager --auth=$TRANSCEND_API_KEY --bundleTypes=PRODUCTION
+yarn tr-upload-data-flows-from-csv --auth=$TRANSCEND_API_KEY --bundleTypes=PRODUCTION
 ```
 
 Update multiple organizations at once
 
 ```sh
-yarn tr-update-consent-manager --auth=$TRANSCEND_API_KEY --bundleTypes=PRODUCTION
+yarn tr-upload-data-flows-from-csv --auth=$TRANSCEND_API_KEY --bundleTypes=PRODUCTION
 
 tr-generate-api-keys  --email=test@transcend.io --password=$TRANSCEND_PASSWORD --scopes="Manage Consent Manager" --apiKeyTitle="CLI Usage Cross Instance Sync" --file=./transcend-api-keys.json
-yarn tr-update-consent-manager  --auth=./transcend-api-keys.json --deploy=true
+yarn tr-upload-data-flows-from-csv  --auth=./transcend-api-keys.json --deploy=true
+```
+
+### tr-upload-data-flows-from-csv
+
+This command allows for uploading of data flows from CSV.
+
+Step 1) Download the CSV of data flows that you want to edit from the Admin Dashboard under [Consent Manager -> Data Flows](https://app.transcend.io/consent-manager/data-flows). You can download data flows from both the "Triage" and "Approved" tabs.
+
+<img width="1464" alt="Screenshot 2023-06-22 at 6 05 36 PM" src="https://github.com/transcend-io/cli/assets/10264973/c4b65b31-2cf3-49c9-b543-041567c7aff8">
+
+Step 2) You can edit the contents of the CSV file as needed. You may adjust the "Purpose" column, adjust the "Notes" column, add "Owners" and "Teams" or even add custom columns with additional metadata.
+Step 3) Upload the modified CSV file back into the dashboard with the command `yarn tr-upload-data-flows-from-csv --auth=$TRANSCEND_API_KEY --file=./approved-flows.csv --trackerStatus=LIVE`
+
+#### Authentication
+
+In order to use this cli, you will first need to generate an API key on the Transcend Admin Dashboard (https://app.transcend.io/infrastructure/api-keys).
+
+The API key must have the following scopes:
+
+- "Manage Data Flows"
+
+#### Arguments
+
+| Argument        | Description                                                                                                | Type                 | Default                  | Required |
+| --------------- | ---------------------------------------------------------------------------------------------------------- | -------------------- | ------------------------ | -------- |
+| auth            | The Transcend API capable of pulling the cron identifiers.                                                 | string               | N/A                      | true     |
+| trackerStatus   | Whether or not to upload the data flows into the "Approved" tab (LIVE) or the "Triage" tab (NEEDS_REVIEW). | ConsentTrackerStatus | N/A                      | true     |
+| file            | Path to the CSV file to upload                                                                             | string - file-path   | ./data-flows.csv         | false    |
+| classifyService | When true, automatically assign the service for a data flow based on the domain that is specified          | boolean              | false                    | false    |
+| transcendUrl    | URL of the Transcend backend. Use https://api.us.transcend.io for US hosting.                              | string - URL         | https://api.transcend.io | false    |
+
+Note: You `trackerStatus` can be specified on a per data flow basis by adding a column named "Status" to the CSV. The values should be of type `ConsentTrackerStatus` - which is `LIVE` or `NEEDS_REVIEW`.
+
+#### Usage
+
+Upload the file of data flows in `./data-flows.csv` into the ["Approved" tab](https://app.transcend.io/consent-manager/data-flows/approved).
+
+```sh
+yarn tr-upload-data-flows-from-csv --auth=$TRANSCEND_API_KEY --trackerStatus=LIVE
+```
+
+Upload the file of data flows in `./data-flows.csv` into the ["Triage" tab](https://app.transcend.io/consent-manager/data-flows).
+
+```sh
+yarn tr-upload-data-flows-from-csv --auth=$TRANSCEND_API_KEY --trackerStatus=NEEDS_REVIEW
+```
+
+Specifying the CSV file to read from:
+
+```sh
+yarn tr-upload-data-flows-from-csv --auth=$TRANSCEND_API_KEY --trackerStatus=LIVE --file=./custom/my-data-flows.csv
+```
+
+Have Transcend automatically fill in the service names by looking up the data flow host in Transcend's database.
+
+```sh
+yarn tr-upload-data-flows-from-csv --auth=$TRANSCEND_API_KEY --trackerStatus=LIVE --classifyService=true
+```
+
+Specifying the backend URL, needed for US hosted backend infrastructure.
+
+```sh
+yarn tr-upload-data-flows-from-csv --auth=$TRANSCEND_API_KEY --trackerStatus=LIVE
 ```
 
 ### tr-generate-api-keys

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "tr-request-restart": "./build/cli-request-restart.js",
     "tr-request-upload": "./build/cli-request-upload.js",
     "tr-retry-request-data-silos": "./build/cli-retry-request-data-silos.js",
-    "tr-update-consent-manager": "./build/cli-update-consent-manager-to-latest.js"
+    "tr-update-consent-manager": "./build/cli-update-consent-manager-to-latest.js",
+    "tr-upload-data-flows-from-csv": "./build/cli-upload-data-flows-from-csv.js"
   },
   "files": [
     "build/**/*",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/cli",
   "description": "Small package containing useful typescript utilities.",
-  "version": "4.55.0",
+  "version": "4.56.0",
   "homepage": "https://github.com/transcend-io/cli",
   "repository": {
     "type": "git",

--- a/src/cli-upload-data-flows-from-csv.ts
+++ b/src/cli-upload-data-flows-from-csv.ts
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+
+import yargs from 'yargs-parser';
+import colors from 'colors';
+
+import { logger } from './logger';
+import { uploadDataFlowsFromCsv } from './consent-manager';
+import { ConsentTrackerStatus } from '@transcend-io/privacy-types';
+
+/**
+ * Upload a CSV of data flows
+ *
+ * Requires an API key with follow scopes: https://app.transcend.io/infrastructure/api-keys
+ *    - "Manage Data Flows"
+ *
+ * Dev Usage:
+ * yarn ts-node ./src/cli-upload-data-flows-from-csv.ts --auth=asd123 \
+ *   --file=/Users/michaelfarrell/Desktop/test.csv \
+ *   --trackerStatus=LIVE
+ *
+ * Standard usage:
+ * yarn tr-upload-data-flows-from-csv --auth=asd123 \
+ *   --file=/Users/michaelfarrell/Desktop/test.csv \
+ *   --trackerStatus=LIVE
+ */
+async function main(): Promise<void> {
+  // Parse command line arguments
+  const {
+    auth,
+    trackerStatus,
+    classifyService = 'false',
+    file = './data-flows.csv',
+    transcendUrl = 'https://api.transcend.io',
+  } = yargs(process.argv.slice(2)) as { [k in string]: string };
+
+  // Ensure auth is passed
+  if (!auth) {
+    logger.error(
+      colors.red(
+        'A Transcend API key must be provided. You can specify using --auth=asd123',
+      ),
+    );
+    process.exit(1);
+  }
+
+  // Ensure trackerStatus is passed
+  const VALID_TRACKER_OPTIONS = Object.values(ConsentTrackerStatus);
+  if (!trackerStatus) {
+    logger.error(
+      colors.red(
+        'The trackerStatus must be provided. You can specify using --trackerStatus=LIVE. ' +
+          `Valid options include: ${VALID_TRACKER_OPTIONS.join(',')}`,
+      ),
+    );
+    process.exit(1);
+  }
+
+  const consentTrackerStatus = trackerStatus as ConsentTrackerStatus;
+  if (!VALID_TRACKER_OPTIONS.includes(consentTrackerStatus)) {
+    logger.error(
+      colors.red(
+        `The trackerStatus option was invalid, got: "${trackerStatus}". You can specify using --trackerStatus=LIVE. ` +
+          `Valid options include: ${VALID_TRACKER_OPTIONS.join(',')}`,
+      ),
+    );
+    process.exit(1);
+  }
+
+  // Upload data flows
+  await uploadDataFlowsFromCsv({
+    auth,
+    trackerStatus: consentTrackerStatus,
+    file,
+    classifyService: classifyService === 'true',
+    transcendUrl,
+  });
+}
+
+main();

--- a/src/consent-manager/index.ts
+++ b/src/consent-manager/index.ts
@@ -1,1 +1,2 @@
 export * from './updateConsentManagerVersionToLatest';
+export * from './uploadDataFlowsFromCsv';

--- a/src/consent-manager/uploadDataFlowsFromCsv.ts
+++ b/src/consent-manager/uploadDataFlowsFromCsv.ts
@@ -1,0 +1,141 @@
+import colors from 'colors';
+import * as t from 'io-ts';
+import { logger } from '../logger';
+import {
+  ConsentTrackerStatus,
+  DataFlowScope,
+} from '@transcend-io/privacy-types';
+import { buildTranscendGraphQLClient, syncDataFlows } from '../graphql';
+import { readCsv } from '../requests/readCsv';
+import { valuesOf } from '@transcend-io/type-utils';
+import { DataFlowInput } from '../codecs';
+import { splitCsvToList } from '../requests';
+
+/**
+ * Minimal set required to mark as completed
+ */
+export const DataFlowCsvInput = t.intersection([
+  t.type({
+    /** The value of the data flow (host or regex) */
+    'Connections Made To': t.string,
+    /** The type of the data flow */
+    Type: valuesOf(DataFlowScope),
+    /** The CSV of purposes mapped to that data flow */
+    Purpose: t.string,
+  }),
+  t.partial({
+    /** The service that the data flow relates to */
+    Service: t.string,
+    /** Notes and descriptions for the data flow */
+    Notes: t.string,
+    /** Set of data flow owners */
+    Owners: t.string,
+    /** Set of data flow team owners */
+    Teams: t.string,
+    /** LIVE vs NEEDS_REVIEW aka Approved vs Triage  */
+    Status: valuesOf(ConsentTrackerStatus),
+  }),
+  // Custom attributes
+  t.record(t.string, t.string),
+]);
+
+const OMIT_COLUMNS = [
+  'ID',
+  'Activity',
+  'Encounters',
+  'Last Seen At',
+  'Has Native Do Not Sell/Share Support',
+  'IAB USP API Support',
+  'Service Description',
+  'Website URL',
+  'Categories of Recipients',
+];
+
+/** Type override */
+export type DataFlowCsvInput = t.TypeOf<typeof DataFlowCsvInput>;
+
+/**
+ * Upload a set of data flows from CSV
+ *
+ * @param options - Options
+ */
+export async function uploadDataFlowsFromCsv({
+  auth,
+  trackerStatus,
+  file,
+  classifyService = false,
+  transcendUrl = 'https://api.transcend.io',
+}: {
+  /** CSV file path */
+  file: string;
+  /** Transcend API key authentication */
+  auth: string;
+  /** Sombra API key authentication */
+  trackerStatus: ConsentTrackerStatus;
+  /** classify data flow service if missing */
+  classifyService?: boolean;
+  /** API URL for Transcend backend */
+  transcendUrl?: string;
+}): Promise<void> {
+  // Build a GraphQL client
+  const client = buildTranscendGraphQLClient(transcendUrl, auth);
+
+  // Read from CSV the set of data flow inputs
+  logger.info(colors.magenta(`Reading "${file}" from disk`));
+  const dataFlowInputs = readCsv(file, DataFlowCsvInput);
+
+  // Convert these data flow inputs into a format that the other function can use
+  const validatedDataFlowInputs = dataFlowInputs.map(
+    ({
+      Type,
+      Notes,
+      // TODO: https://transcend.height.app/T-26391 - export in CSV
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      Service,
+      Purpose,
+      Status,
+      Owners,
+      Teams,
+      'Connections Made To': value,
+      ...rest
+    }): DataFlowInput => ({
+      value,
+      type: Type,
+      description: Notes,
+      trackingPurposes: splitCsvToList(Purpose),
+      // TODO: https://transcend.height.app/T-26391
+      // service: Service,
+      // Apply the trackerStatus to all values in the CSV -> allows for customer to define tracker status
+      // on a row by row basis if needed
+      status: Status || trackerStatus,
+      owners: Owners ? splitCsvToList(Owners) : undefined,
+      teams: Teams ? splitCsvToList(Teams) : undefined,
+      // all remaining options are attribute
+      attributes: Object.entries(rest)
+        // filter out native columns that are exported from the admin dashboard
+        // but not custom attributes
+        .filter(([key]) => !OMIT_COLUMNS.includes(key))
+        .map(([key, value]) => ({
+          key,
+          values: splitCsvToList(value),
+        })),
+    }),
+  );
+
+  // Upload the data flows into Transcend dashboard
+  const syncedDataFlows = await syncDataFlows(
+    client,
+    validatedDataFlowInputs,
+    classifyService,
+  );
+
+  // Log errors
+  if (!syncedDataFlows) {
+    logger.error(
+      colors.red(
+        'Encountered error(s) syncing data flows from CSV, see logs above for more info. ',
+      ),
+    );
+    process.exit(1);
+  }
+}

--- a/src/graphql/gqls/consentManager.ts
+++ b/src/graphql/gqls/consentManager.ts
@@ -60,11 +60,16 @@ export const CREATE_DATA_FLOWS = gql`
 
 export const UPDATE_DATA_FLOWS = gql`
   mutation TranscendCliUpdateDataFlows(
+    $airgapBundleId: ID!
     $dataFlows: [UpdateDataFlowInput!]!
     $classifyService: Boolean
   ) {
     updateDataFlows(
-      input: { dataFlows: $dataFlows, classifyService: $classifyService }
+      input: {
+        airgapBundleId: $airgapBundleId
+        dataFlows: $dataFlows
+        classifyService: $classifyService
+      }
     ) {
       dataFlows {
         id

--- a/src/graphql/syncDataFlows.ts
+++ b/src/graphql/syncDataFlows.ts
@@ -3,9 +3,12 @@ import { CREATE_DATA_FLOWS, UPDATE_DATA_FLOWS } from './gqls';
 import chunk from 'lodash/chunk';
 import { mapSeries } from 'bluebird';
 import { DataFlowInput } from '../codecs';
-// import keyBy from 'lodash/keyBy';
 import { makeGraphQLRequest } from './makeGraphQLRequest';
 import { fetchConsentManagerId } from './fetchConsentManagerId';
+import { logger } from '../logger';
+import colors from 'colors';
+import { fetchAllDataFlows } from './fetchAllDataFlows';
+import { ConsentTrackerStatus } from '@transcend-io/privacy-types';
 
 const MAX_PAGE_SIZE = 100;
 
@@ -21,12 +24,15 @@ export async function updateDataFlows(
   dataFlowInputs: [DataFlowInput, string][],
   classifyService = false,
 ): Promise<void> {
+  const airgapBundleId = await fetchConsentManagerId(client);
+
   // TODO: https://transcend.height.app/T-19841 - add with custom purposes
   // const purposes = await fetchPurposes(client);
   // const purposeNameToId = keyBy(purposes, 'name');
 
   await mapSeries(chunk(dataFlowInputs, MAX_PAGE_SIZE), async (page) => {
     await makeGraphQLRequest(client, UPDATE_DATA_FLOWS, {
+      airgapBundleId,
       dataFlows: page.map(([flow, id]) => ({
         id,
         value: flow.value,
@@ -98,4 +104,96 @@ export async function createDataFlows(
       classifyService,
     });
   });
+}
+
+/**
+ * Sync data flow configurations into Transcend
+ *
+ * @param client - GraphQL client
+ * @param dataFlows - The data flows to upload
+ * @param classifyService - When true, auto classify the service based on the data flow value
+ * @returns True if the command ran successfully, returns false if an error occurred
+ */
+export async function syncDataFlows(
+  client: GraphQLClient,
+  dataFlows: DataFlowInput[],
+  classifyService: boolean,
+): Promise<boolean> {
+  let encounteredError = false;
+  logger.info(colors.magenta(`Syncing "${dataFlows.length}" data flows...`));
+
+  // Ensure no duplicates are being uploaded
+  // De-dupe the data flows based on [value, type]
+  const notUnique = dataFlows.filter(
+    (dataFlow) =>
+      dataFlows.filter(
+        (flow) => dataFlow.value === flow.value && dataFlow.type === flow.type,
+      ).length > 1,
+  );
+
+  // Throw error to prompt user to de-dupe before uploading
+  if (notUnique.length > 0) {
+    throw new Error(
+      `Failed to upload data flows as there were non-unique entries found: ${notUnique
+        .map(({ value }) => value)
+        .join(',')}`,
+    );
+  }
+
+  // Fetch existing data flows to determine whether we are creating a new data flow
+  // or updating an existing data flow
+  const [existingLiveDataFlows, existingInReviewDataFlows] = await Promise.all([
+    fetchAllDataFlows(client, ConsentTrackerStatus.Live),
+    fetchAllDataFlows(client, ConsentTrackerStatus.NeedsReview),
+  ]);
+  const allDataFlows = [...existingLiveDataFlows, ...existingInReviewDataFlows];
+
+  // Determine which data flows are new vs existing
+  const mapDataFlowsToExisting = dataFlows.map((dataFlow) => [
+    dataFlow,
+    allDataFlows.find(
+      (flow) => dataFlow.value === flow.value && dataFlow.type === flow.type,
+    )?.id,
+  ]);
+
+  // Create the new data flows
+  const newDataFlows = mapDataFlowsToExisting
+    .filter(([, existing]) => !existing)
+    .map(([flow]) => flow as DataFlowInput);
+  try {
+    logger.info(
+      colors.magenta(`Creating "${newDataFlows.length}" new data flows...`),
+    );
+    await createDataFlows(client, newDataFlows, classifyService);
+    logger.info(
+      colors.green(`Successfully synced ${newDataFlows.length} data flows!`),
+    );
+  } catch (err) {
+    encounteredError = true;
+    logger.info(colors.red(`Failed to create data flows! - ${err.message}`));
+  }
+
+  // Update existing data flows
+  const existingDataFlows = mapDataFlowsToExisting.filter(
+    (x): x is [DataFlowInput, string] => !!x[1],
+  );
+  try {
+    logger.info(
+      colors.magenta(`Updating "${existingDataFlows.length}" data flows...`),
+    );
+    await updateDataFlows(client, existingDataFlows, classifyService);
+    logger.info(
+      colors.green(
+        `Successfully updated "${existingDataFlows.length}" data flows!`,
+      ),
+    );
+  } catch (err) {
+    encounteredError = true;
+    logger.info(colors.red(`Failed to create data flows! - ${err.message}`));
+  }
+
+  logger.info(colors.green(`Synced "${dataFlows.length}" data flows!`));
+
+  // Return true upon success
+  return !encounteredError;
 }

--- a/src/requests/splitCsvToList.ts
+++ b/src/requests/splitCsvToList.ts
@@ -1,6 +1,10 @@
 /**
  * Split string to CSV
  *
+ * Filter out double commas and spaces like:
+ * Dog, Cat -> ['Dog', 'Cat']
+ * Dog,,Cat -> ['Dog', 'Cat']
+ *
  * @param value - Value
  * @returns List of values
  */

--- a/yarn.lock
+++ b/yarn.lock
@@ -465,6 +465,7 @@ __metadata:
     tr-request-upload: ./build/cli-request-upload.js
     tr-retry-request-data-silos: ./build/cli-retry-request-data-silos.js
     tr-update-consent-manager: ./build/cli-update-consent-manager-to-latest.js
+    tr-upload-data-flows-from-csv: ./build/cli-upload-data-flows-from-csv.js
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Related Issues

- closes https://transcend.height.app/T-26213


This command allows for uploading of data flows from CSV.

Step 1) Download the CSV of data flows that you want to edit from the Admin Dashboard under [Consent Manager -> Data Flows](https://app.transcend.io/consent-manager/data-flows). You can download data flows from both the "Triage" and "Approved" tabs.

<img width="1464" alt="Screenshot 2023-06-22 at 6 05 36 PM" src="https://github.com/transcend-io/cli/assets/10264973/c4b65b31-2cf3-49c9-b543-041567c7aff8">

Step 2) You can edit the contents of the CSV file as needed. You may adjust the "Purpose" column, adjust the "Notes" column, add "Owners" and "Teams" or even add custom columns with additional metadata.
Step 3) Upload the modified CSV file back into the dashboard with the command `yarn tr-upload-data-flows-from-csv --auth=$TRANSCEND_API_KEY --file=./approved-flows.csv --trackerStatus=LIVE`

#### Authentication

In order to use this cli, you will first need to generate an API key on the Transcend Admin Dashboard (https://app.transcend.io/infrastructure/api-keys).

The API key must have the following scopes:

- "Manage Data Flows"

#### Arguments

| Argument        | Description                                                                                                | Type                 | Default                  | Required |
| --------------- | ---------------------------------------------------------------------------------------------------------- | -------------------- | ------------------------ | -------- |
| auth            | The Transcend API key with the scopes necessary for the command.                                                 | string               | N/A                      | true     |
| trackerStatus   | Whether or not to upload the data flows into the "Approved" tab (LIVE) or the "Triage" tab (NEEDS_REVIEW). | ConsentTrackerStatus | N/A                      | true     |
| file            | Path to the CSV file to upload                                                                             | string - file-path   | ./data-flows.csv         | false    |
| classifyService | When true, automatically assign the service for a data flow based on the domain that is specified          | boolean              | false                    | false    |
| transcendUrl    | URL of the Transcend backend. Use https://api.us.transcend.io for US hosting.                              | string - URL         | https://api.transcend.io | false    |

Note: You `trackerStatus` can be specified on a per data flow basis by adding a column named "Status" to the CSV. The values should be of type `ConsentTrackerStatus` - which is `LIVE` or `NEEDS_REVIEW`.

#### Usage

Upload the file of data flows in `./data-flows.csv` into the ["Approved" tab](https://app.transcend.io/consent-manager/data-flows/approved).

```sh
yarn tr-upload-data-flows-from-csv --auth=$TRANSCEND_API_KEY --trackerStatus=LIVE
```

Upload the file of data flows in `./data-flows.csv` into the ["Triage" tab](https://app.transcend.io/consent-manager/data-flows).

```sh
yarn tr-upload-data-flows-from-csv --auth=$TRANSCEND_API_KEY --trackerStatus=NEEDS_REVIEW
```

Specifying the CSV file to read from:

```sh
yarn tr-upload-data-flows-from-csv --auth=$TRANSCEND_API_KEY --trackerStatus=LIVE --file=./custom/my-data-flows.csv
```

Have Transcend automatically fill in the service names by looking up the data flow host in Transcend's database.

```sh
yarn tr-upload-data-flows-from-csv --auth=$TRANSCEND_API_KEY --trackerStatus=LIVE --classifyService=true
```

Specifying the backend URL, needed for US hosted backend infrastructure.

```sh
yarn tr-upload-data-flows-from-csv --auth=$TRANSCEND_API_KEY --trackerStatus=LIVE
```

