### PR TITLE
Adds cli command to approve requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,54 +21,58 @@
     - [Authentication](#authentication-2)
     - [Usage](#usage-3)
     - [Arguments](#arguments-2)
-  - [tr-request-upload](#tr-request-upload)
+  - [tr-request-approve](#tr-request-approve)
     - [Authentication](#authentication-3)
     - [Arguments](#arguments-3)
     - [Usage](#usage-4)
-  - [tr-request-restart](#tr-request-restart)
+  - [tr-request-upload](#tr-request-upload)
     - [Authentication](#authentication-4)
     - [Arguments](#arguments-4)
     - [Usage](#usage-5)
-  - [tr-request-export](#tr-request-export)
+  - [tr-request-restart](#tr-request-restart)
     - [Authentication](#authentication-5)
     - [Arguments](#arguments-5)
     - [Usage](#usage-6)
-  - [tr-cron-pull-identifiers](#tr-cron-pull-identifiers)
+  - [tr-request-export](#tr-request-export)
     - [Authentication](#authentication-6)
     - [Arguments](#arguments-6)
     - [Usage](#usage-7)
-  - [tr-cron-mark-identifiers-completed](#tr-cron-mark-identifiers-completed)
+  - [tr-cron-pull-identifiers](#tr-cron-pull-identifiers)
     - [Authentication](#authentication-7)
     - [Arguments](#arguments-7)
     - [Usage](#usage-8)
-  - [tr-manual-enrichment-pull-identifiers](#tr-manual-enrichment-pull-identifiers)
+  - [tr-cron-mark-identifiers-completed](#tr-cron-mark-identifiers-completed)
     - [Authentication](#authentication-8)
     - [Arguments](#arguments-8)
     - [Usage](#usage-9)
-  - [tr-manual-enrichment-push-identifiers](#tr-manual-enrichment-push-identifiers)
+  - [tr-manual-enrichment-pull-identifiers](#tr-manual-enrichment-pull-identifiers)
     - [Authentication](#authentication-9)
     - [Arguments](#arguments-9)
     - [Usage](#usage-10)
-  - [tr-mark-request-data-silos-completed](#tr-mark-request-data-silos-completed)
+  - [tr-manual-enrichment-push-identifiers](#tr-manual-enrichment-push-identifiers)
     - [Authentication](#authentication-10)
     - [Arguments](#arguments-10)
     - [Usage](#usage-11)
-  - [tr-retry-request-data-silos](#tr-retry-request-data-silos)
+  - [tr-mark-request-data-silos-completed](#tr-mark-request-data-silos-completed)
     - [Authentication](#authentication-11)
     - [Arguments](#arguments-11)
     - [Usage](#usage-12)
-  - [tr-update-consent-manager](#tr-update-consent-manager)
+  - [tr-retry-request-data-silos](#tr-retry-request-data-silos)
     - [Authentication](#authentication-12)
     - [Arguments](#arguments-12)
     - [Usage](#usage-13)
-  - [tr-upload-data-flows-from-csv](#tr-upload-data-flows-from-csv)
+  - [tr-update-consent-manager](#tr-update-consent-manager)
     - [Authentication](#authentication-13)
     - [Arguments](#arguments-13)
     - [Usage](#usage-14)
-  - [tr-generate-api-keys](#tr-generate-api-keys)
+  - [tr-upload-data-flows-from-csv](#tr-upload-data-flows-from-csv)
     - [Authentication](#authentication-14)
     - [Arguments](#arguments-14)
     - [Usage](#usage-15)
+  - [tr-generate-api-keys](#tr-generate-api-keys)
+    - [Authentication](#authentication-15)
+    - [Arguments](#arguments-15)
+    - [Usage](#usage-16)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -90,6 +94,7 @@ yarn add -D @transcend-io/cli
 yarn tr-pull --auth=$TRANSCEND_API_KEY
 yarn tr-push --auth=$TRANSCEND_API_KEY
 yarn tr-discover-silos --auth=$TRANSCEND_API_KEY
+yarn tr-request-approve --auth=$TRANSCEND_API_KEY
 yarn tr-request-upload --auth=$TRANSCEND_API_KEY
 yarn tr-request-export --auth=$TRANSCEND_API_KEY
 yarn tr-request-restart --auth=$TRANSCEND_API_KEY
@@ -113,6 +118,7 @@ npm i -D @transcend-io/cli
 tr-pull --auth=$TRANSCEND_API_KEY
 tr-push --auth=$TRANSCEND_API_KEY
 tr-discover-silos --auth=$TRANSCEND_API_KEY
+tr-request-approve --auth=$TRANSCEND_API_KEY
 tr-request-upload --auth=$TRANSCEND_API_KEY
 tr-request-export --auth=$TRANSCEND_API_KEY
 tr-request-restart --auth=$TRANSCEND_API_KEY
@@ -134,12 +140,7 @@ npm i -g @transcend-io/cli
 
 # cli commands available everywhere on machine
 tr-pull --auth=$TRANSCEND_API_KEY
-tr-push --auth=$TRANSCEND_API_KEY
-tr-discover-silos --auth=$TRANSCEND_API_KEY
-tr-request-upload --auth=$TRANSCEND_API_KEY
-tr-request-restart --auth=$TRANSCEND_API_KEY
-tr-cron-pull-identifiers --auth=$TRANSCEND_API_KEY
-tr-cron-mark-identifiers-completed --auth=$TRANSCEND_API_KEY
+...
 ```
 
 Note:
@@ -599,6 +600,56 @@ You can include additional arguments as well:
 | dataSiloID | The UUID of the corresponding data silo.                                                                                                                             | string | N/A     | true     |
 | auth       | Transcend API key.                                                                                                                                                   | string | N/A     | true     |
 | fileGlobs  | You can pass a [glob syntax pattern(s)](https://github.com/mrmlnc/fast-glob) to specify additional file paths to scan in addition to the default (ex: package.json). | string | N/A     | false    |
+
+### tr-request-approve
+
+Bulk approve a set of privacy requests from the [Privacy Requests -> Incoming Requests](https://app.transcend.io/privacy-requests/incoming-requests) tab.
+
+#### Authentication
+
+In order to use this cli, you will first need to generate an API key on the Transcend Admin Dashboard (https://app.transcend.io/infrastructure/api-keys).
+
+The API key needs the following scopes:
+
+- Request Approval and Communication
+- View Incoming Requests
+- Manage Request Compilation
+
+#### Arguments
+
+| Argument         | Description                                                                                                                                | Type            | Default                  | Required |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | --------------- | ------------------------ | -------- |
+| auth             | The Transcend API key with the scopes necessary for the command.                                                                           | string          | N/A                      | true     |
+| actions          | The [request actions](https://docs.transcend.io/docs/privacy-requests/configuring-requests/data-subject-requests#data-actions) to approve. | RequestAction[] | N/A                      | true     |
+| silentModeBefore | Any requests made before this date should be marked as silent mode                                                                         | Date            | N/A                      | false    |
+| transcendUrl     | URL of the Transcend backend. Use https://api.us.transcend.io for US hosting.                                                              | string - URL    | https://api.transcend.io | false    |
+| concurrency      | The concurrency to use when uploading requests in parallel.                                                                                | number          | 100                      | false    |
+
+#### Usage
+
+Bulk approve all SALE_OPT_OUT and ERASURE requests
+
+```sh
+yarn tr-request-approve --auth=$TRANSCEND_API_KEY --actions=SALE_OPT_OUT,ERASURE
+```
+
+Specifying the backend URL, needed for US hosted backend infrastructure.
+
+```sh
+yarn tr-request-approve --auth=$TRANSCEND_API_KEY --actions=ERASURE --transcendUrl=https://api.us.transcend.io
+```
+
+Approve all requests, but mark any request made before 05/03/2023 as silent mode to prevent emailing the individual.
+
+```sh
+yarn tr-request-approve --auth=$TRANSCEND_API_KEY --actions=SALE_OPT_OUT --silentModeBefore=05/03/2023
+```
+
+Increase the concurrency (defaults to 100)
+
+```sh
+yarn tr-request-approve --auth=$TRANSCEND_API_KEY --actions=ERASURE --concurrency=500
+```
 
 ### tr-request-upload
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/cli",
   "description": "Small package containing useful typescript utilities.",
-  "version": "4.56.0",
+  "version": "4.57.0",
   "homepage": "https://github.com/transcend-io/cli",
   "repository": {
     "type": "git",
@@ -20,6 +20,7 @@
     "tr-mark-request-data-silos-completed": "./build/cli-mark-request-data-silos-completed.js",
     "tr-pull": "./build/cli-pull.js",
     "tr-push": "./build/cli-push.js",
+    "tr-request-approve": "./build/cli-request-approve.js",
     "tr-request-export": "./build/cli-request-export.js",
     "tr-request-restart": "./build/cli-request-restart.js",
     "tr-request-upload": "./build/cli-request-upload.js",

--- a/src/cli-request-approve.ts
+++ b/src/cli-request-approve.ts
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+
+import yargs from 'yargs-parser';
+import colors from 'colors';
+
+import { logger } from './logger';
+import { RequestAction } from '@transcend-io/privacy-types';
+import { splitCsvToList, approvePrivacyRequests } from './requests';
+
+/**
+ * Restart requests based on some filter criteria
+ *
+ * Requires scopes:
+ * - Request Approval and Communication
+ * - View Incoming Requests
+ * - Manage Request Compilation
+ *
+ * Dev Usage:
+ * yarn ts-node ./src/cli-request-approve.ts --auth=asd123 \
+ *   --requestType=ERASURE --silentModeBefore=06/23/2023
+ *
+ * Standard usage:
+ * yarn tr-request-export --auth=asd123  \
+ *   --requestType=ERASURE --silentModeBefore=06/23/2023
+ */
+async function main(): Promise<void> {
+  // Parse command line arguments
+  const {
+    transcendUrl = 'https://api.transcend.io',
+    auth,
+    actions = '',
+    silentModeBefore,
+    concurrency = '100',
+  } = yargs(process.argv.slice(2)) as { [k in string]: string };
+
+  // Ensure auth is passed
+  if (!auth) {
+    logger.error(
+      colors.red(
+        'A Transcend API key must be provided. You can specify using --auth=asd123',
+      ),
+    );
+    process.exit(1);
+  }
+
+  // Validate actions
+  const parsedActions = splitCsvToList(actions) as RequestAction[];
+  const invalidActions = parsedActions.filter(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (type) => !Object.values(RequestAction).includes(type as any),
+  );
+  if (invalidActions.length > 0) {
+    logger.error(
+      colors.red(
+        `Failed to parse actions:"${invalidActions.join(',')}".\n` +
+          `Expected one of: \n${Object.values(RequestAction).join('\n')}`,
+      ),
+    );
+    process.exit(1);
+  }
+
+  // Pull privacy requests
+  await approvePrivacyRequests({
+    transcendUrl,
+    requestActions: parsedActions,
+    auth,
+    concurrency: parseInt(concurrency, 10),
+    silentModeBefore: silentModeBefore ? new Date(silentModeBefore) : undefined,
+  });
+}
+
+main();

--- a/src/graphql/gqls/request.ts
+++ b/src/graphql/gqls/request.ts
@@ -36,3 +36,23 @@ export const REQUESTS = gql`
     }
   }
 `;
+
+export const APPROVE_PRIVACY_REQUESTS = gql`
+  mutation TranscendCliApprovePrivacyRequest($input: CommunicationInput!) {
+    approveRequest(input: $input) {
+      request {
+        id
+      }
+    }
+  }
+`;
+
+export const UPDATE_PRIVACY_REQUEST = gql`
+  mutation TranscendCliUpdatePrivacyRequest($input: UpdateRequestInput!) {
+    updateRequest(input: $input) {
+      request {
+        id
+      }
+    }
+  }
+`;

--- a/src/requests/approvePrivacyRequests.ts
+++ b/src/requests/approvePrivacyRequests.ts
@@ -1,0 +1,100 @@
+import { map } from 'bluebird';
+import colors from 'colors';
+import { logger } from '../logger';
+import { RequestAction, RequestStatus } from '@transcend-io/privacy-types';
+import {
+  UPDATE_PRIVACY_REQUEST,
+  fetchAllRequests,
+  makeGraphQLRequest,
+  buildTranscendGraphQLClient,
+  APPROVE_PRIVACY_REQUESTS,
+} from '../graphql';
+import cliProgress from 'cli-progress';
+
+/**
+ * Approve a set of privacy requests
+ *
+ * @param options - Options
+ * @returns The number of requests approved
+ */
+export async function approvePrivacyRequests({
+  requestActions,
+  auth,
+  silentModeBefore,
+  concurrency = 100,
+  transcendUrl = 'https://api.transcend.io',
+}: {
+  /** The request actions that should be restarted */
+  requestActions: RequestAction[];
+  /** Transcend API key authentication */
+  auth: string;
+  /** Concurrency limit for approving */
+  concurrency?: number;
+  /** Mark these requests as silent mode if they were created before this date */
+  silentModeBefore?: Date;
+  /** API URL for Transcend backend */
+  transcendUrl?: string;
+}): Promise<number> {
+  // Find all requests made before createdAt that are in a removing data state
+  const client = buildTranscendGraphQLClient(transcendUrl, auth);
+
+  // Time duration
+  const t0 = new Date().getTime();
+  // create a new progress bar instance and use shades_classic theme
+  const progressBar = new cliProgress.SingleBar(
+    {},
+    cliProgress.Presets.shades_classic,
+  );
+
+  // Pull in the requests
+  const allRequests = await fetchAllRequests(client, {
+    actions: requestActions,
+    statuses: [RequestStatus.Approving],
+  });
+
+  // Notify Transcend
+  logger.info(colors.magenta(`Approving "${allRequests.length}" requests.`));
+
+  let total = 0;
+  progressBar.start(allRequests.length, 0);
+  await map(
+    allRequests,
+    async (requestToRestart) => {
+      // update request to silent mode if silentModeBefore is defined
+      // and the request was created before silentModeBefore
+      if (
+        silentModeBefore &&
+        new Date(silentModeBefore) > new Date(requestToRestart.createdAt)
+      ) {
+        await makeGraphQLRequest(client, UPDATE_PRIVACY_REQUEST, {
+          input: {
+            id: requestToRestart.id,
+            isSilent: true,
+          },
+        });
+      }
+
+      // approve the request
+      await makeGraphQLRequest(client, APPROVE_PRIVACY_REQUESTS, {
+        input: { requestId: requestToRestart.id },
+      });
+
+      total += 1;
+      progressBar.update(total);
+    },
+    { concurrency },
+  );
+
+  progressBar.stop();
+  const t1 = new Date().getTime();
+  const totalTime = t1 - t0;
+
+  logger.info(
+    colors.green(
+      `Successfully approved ${total} requests in "${
+        totalTime / 1000
+      }" seconds!`,
+    ),
+  );
+  return allRequests.length;
+}

--- a/src/requests/index.ts
+++ b/src/requests/index.ts
@@ -10,6 +10,7 @@ export * from './mapCsvColumnsToApi';
 export * from './mapRequestEnumValues';
 export * from './mapCsvRowsToRequestInputs';
 export * from './submitPrivacyRequest';
+export * from './approvePrivacyRequests';
 export * from './mapColumnsToIdentifiers';
 export * from './mapColumnsToAttributes';
 export * from './extractClientError';

--- a/yarn.lock
+++ b/yarn.lock
@@ -460,6 +460,7 @@ __metadata:
     tr-mark-request-data-silos-completed: ./build/cli-mark-request-data-silos-completed.js
     tr-pull: ./build/cli-pull.js
     tr-push: ./build/cli-push.js
+    tr-request-approve: ./build/cli-request-approve.js
     tr-request-export: ./build/cli-request-export.js
     tr-request-restart: ./build/cli-request-restart.js
     tr-request-upload: ./build/cli-request-upload.js


### PR DESCRIPTION
## Related Issues

- links https://transcend.height.app/T-20722

### tr-request-approve

Bulk approve a set of privacy requests from the [Privacy Requests -> Incoming Requests](https://app.transcend.io/privacy-requests/incoming-requests) tab.

#### Authentication

In order to use this cli, you will first need to generate an API key on the Transcend Admin Dashboard (https://app.transcend.io/infrastructure/api-keys).

The API key needs the following scopes:

- Request Approval and Communication
- View Incoming Requests
- Manage Request Compilation

#### Arguments

| Argument         | Description                                                                                                                                | Type            | Default                  | Required |
| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | --------------- | ------------------------ | -------- |
| auth             | The Transcend API key with the scopes necessary for the command.                                                                           | string          | N/A                      | true     |
| actions          | The [request actions](https://docs.transcend.io/docs/privacy-requests/configuring-requests/data-subject-requests#data-actions) to approve. | RequestAction[] | N/A                      | true     |
| silentModeBefore | Any requests made before this date should be marked as silent mode                                                                         | Date         | true                     | false    |
| transcendUrl     | URL of the Transcend backend. Use https://api.us.transcend.io for US hosting.                                                              | string - URL    | https://api.transcend.io | false    |
| concurrency      | The concurrency to use when uploading requests in parallel.                                                                                | number          | 100                      | false    |

#### Usage

Bulk approve all SALE_OPT_OUT and ERASURE requests

```sh
yarn tr-request-approve --auth=$TRANSCEND_API_KEY --actions=SALE_OPT_OUT,ERASURE
```

Specifying the backend URL, needed for US hosted backend infrastructure.

```sh
yarn tr-request-approve --auth=$TRANSCEND_API_KEY --actions=ERASURE --transcendUrl=https://api.us.transcend.io
```

Approve all requests, but mark any request made before 05/03/2023 as silent mode to prevent emailing the individual.

```sh
yarn tr-request-approve --auth=$TRANSCEND_API_KEY --actions=ERASURE  --silentModeBefore=05/03/2023
```

Increase the concurrency (defaults to 100)

```sh
yarn tr-request-approve --auth=$TRANSCEND --concurrency=500