### PR TITLE
`tr-pull-consent-metrics ` - pull consent manager metrics

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -63,6 +63,7 @@
     "subdatapoint",
     "subdatapoints",
     "thlorenz",
+    "Timeseries",
     "tsbuildinfo",
     "Upserting",
     "uspapi",

--- a/README.md
+++ b/README.md
@@ -73,14 +73,18 @@
     - [Authentication](#authentication-15)
     - [Arguments](#arguments-15)
     - [Usage](#usage-16)
-  - [tr-upload-data-flows-from-csv](#tr-upload-data-flows-from-csv)
+  - [tr-pull-consent-metrics](#tr-pull-consent-metrics)
     - [Authentication](#authentication-16)
     - [Arguments](#arguments-16)
     - [Usage](#usage-17)
-  - [tr-generate-api-keys](#tr-generate-api-keys)
+  - [tr-upload-data-flows-from-csv](#tr-upload-data-flows-from-csv)
     - [Authentication](#authentication-17)
     - [Arguments](#arguments-17)
     - [Usage](#usage-18)
+  - [tr-generate-api-keys](#tr-generate-api-keys)
+    - [Authentication](#authentication-18)
+    - [Arguments](#arguments-18)
+    - [Usage](#usage-19)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -1393,7 +1397,7 @@ The API key must have the following scopes:
 yarn tr-update-consent-manager --auth=$TRANSCEND_API_KEY
 ```
 
-Specifying the backend URL, needed for US hosted backend infrastructu re.
+Specifying the backend URL, needed for US hosted backend infrastructure.
 
 ```sh
 yarn tr-update-consent-manager --auth=$TRANSCEND_API_KEY --transcendUrl=https://api.us.transcend.io
@@ -1424,6 +1428,59 @@ yarn tr-update-consent-manager --auth=$TRANSCEND_API_KEY --bundleTypes=PRODUCTIO
 
 tr-generate-api-keys  --email=test@transcend.io --password=$TRANSCEND_PASSWORD --scopes="Manage Consent Manager" --apiKeyTitle="CLI Usage Cross Instance Sync" --file=./transcend-api-keys.json
 yarn tr-update-consent-manager  --auth=./transcend-api-keys.json --deploy=true
+```
+
+### tr-pull-consent-metrics
+
+This command allows for pulling consent manager metrics for a Transcend account, or a set of Transcend accounts.
+
+#### Authentication
+
+In order to use this cli, you will first need to generate an API key on the Transcend Admin Dashboard (https://app.transcend.io/infrastructure/api-keys).
+
+The API key must have the following scopes:
+
+- "View Consent Manager"
+
+#### Arguments
+
+| Argument     | Description                                                                   | Type                    | Default                  | Required |
+| ------------ | ----------------------------------------------------------------------------- | ----------------------- | ------------------------ | -------- |
+| auth         | The Transcend API key with the scopes necessary for the command.              | string                  | N/A                      | true     |
+| start        | The start date to pull metrics from.                                          | string - date           | N/A                      | true     |
+| end          | The end date to pull metrics until.                                           | string - date           | now()                    | true     |
+| folder       | The folder to save metrics to                                                 | string - path           | ./consent-metrics/       | false    |
+| bin          | The bin metric when pulling data (1h or 1d)                                   | ConsentManagerMetricBin | 1d                       | false    |
+| transcendUrl | URL of the Transcend backend. Use https://api.us.transcend.io for US hosting. | string - URL            | https://api.transcend.io | false    |
+
+#### Usage
+
+```sh
+yarn tr-pull-consent-metrics --auth=$TRANSCEND_API_KEY --start=01/01/2023
+```
+
+Specifying the backend URL, needed for US hosted backend infrastructure.
+
+```sh
+yarn tr-pull-consent-metrics --auth=$TRANSCEND_API_KEY --start=01/01/2023 --transcendUrl=https://api.us.transcend.io
+```
+
+Pull start and end date explicitly
+
+```sh
+yarn tr-pull-consent-metrics --auth=$TRANSCEND_API_KEY --start=01/01/2023 --end=03/01/2023
+```
+
+Save to an explicit folder
+
+```sh
+yarn tr-pull-consent-metrics --auth=$TRANSCEND_API_KEY --start=01/01/2023 --end=03/01/2023 --folder=./my-folder/
+```
+
+Bin data hourly vs daily
+
+```sh
+yarn tr-pull-consent-metrics --auth=$TRANSCEND_API_KEY --start=01/01/2023 --bin=1h
 ```
 
 ### tr-upload-data-flows-from-csv

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/cli",
   "description": "Small package containing useful typescript utilities.",
-  "version": "4.62.0",
+  "version": "4.63.0",
   "homepage": "https://github.com/transcend-io/cli",
   "repository": {
     "type": "git",
@@ -19,6 +19,7 @@
     "tr-manual-enrichment-push-identifiers": "./build/cli-manual-enrichment-push-identifiers.js",
     "tr-mark-request-data-silos-completed": "./build/cli-mark-request-data-silos-completed.js",
     "tr-pull": "./build/cli-pull.js",
+    "tr-pull-consent-metrics": "./build/cli-pull-consent-metrics.js",
     "tr-push": "./build/cli-push.js",
     "tr-request-approve": "./build/cli-request-approve.js",
     "tr-request-cancel": "./build/cli-request-cancel.js",

--- a/src/cli-pull-consent-metrics.ts
+++ b/src/cli-pull-consent-metrics.ts
@@ -121,8 +121,6 @@ async function main(): Promise<void> {
         logger.info(
           colors.magenta(`Writing configuration to file "${file}"...`),
         );
-        console.log(file);
-        console.log(metrics);
         writeCsv(file, metrics);
       });
     } catch (err) {
@@ -170,8 +168,6 @@ async function main(): Promise<void> {
           logger.info(
             colors.magenta(`Writing configuration to file "${file}"...`),
           );
-          console.log(file);
-          console.log(metrics);
           writeCsv(file, metrics);
         });
 

--- a/src/cli-pull-consent-metrics.ts
+++ b/src/cli-pull-consent-metrics.ts
@@ -98,7 +98,7 @@ async function main(): Promise<void> {
 
   logger.info(
     colors.magenta(
-      `Pulling consent metrics from start=${startDate.toString()} to end=${endDate.toISOString()}`,
+      `Pulling consent metrics from start=${startDate.toString()} to end=${endDate.toISOString()} with bin size "${bin}"`,
     ),
   );
 
@@ -117,11 +117,19 @@ async function main(): Promise<void> {
 
       // Write to file
       Object.entries(configuration).forEach(([metricName, metrics]) => {
-        const file = join(folder, `${metricName}.csv`);
-        logger.info(
-          colors.magenta(`Writing configuration to file "${file}"...`),
-        );
-        writeCsv(file, metrics);
+        metrics.forEach(({ points, name }) => {
+          const file = join(folder, `${metricName}_${name}.csv`);
+          logger.info(
+            colors.magenta(`Writing configuration to file "${file}"...`),
+          );
+          writeCsv(
+            file,
+            points.map(({ key, value }) => ({
+              timestamp: key,
+              value,
+            })),
+          );
+        });
       });
     } catch (err) {
       logger.error(
@@ -164,11 +172,19 @@ async function main(): Promise<void> {
 
         // Write to file
         Object.entries(configuration).forEach(([metricName, metrics]) => {
-          const file = join(subFolder, `${metricName}.csv`);
-          logger.info(
-            colors.magenta(`Writing configuration to file "${file}"...`),
-          );
-          writeCsv(file, metrics);
+          metrics.forEach(({ points, name }) => {
+            const file = join(subFolder, `${metricName}_${name}.csv`);
+            logger.info(
+              colors.magenta(`Writing configuration to file "${file}"...`),
+            );
+            writeCsv(
+              file,
+              points.map(({ key, value }) => ({
+                timestamp: key,
+                value,
+              })),
+            );
+          });
         });
 
         logger.info(

--- a/src/cli-pull-consent-metrics.ts
+++ b/src/cli-pull-consent-metrics.ts
@@ -1,0 +1,201 @@
+#!/usr/bin/env node
+
+import yargs from 'yargs-parser';
+import { logger } from './logger';
+import colors from 'colors';
+import { mapSeries } from 'bluebird';
+import { join } from 'path';
+import fs, { existsSync, mkdirSync } from 'fs';
+import {
+  buildTranscendGraphQLClient,
+  ConsentManagerMetricBin,
+} from './graphql';
+import { validateTranscendAuth } from './api-keys';
+import { ADMIN_DASH_INTEGRATIONS } from './constants';
+import { pullConsentManagerMetrics } from './consent-manager';
+import { writeCsv } from './cron';
+
+/**
+ * Pull down consent manager metrics for 1 or multiple consent managers
+ *
+ * Dev Usage:
+ * yarn ts-node ./src/cli-pull-consent-metrics.ts --folder=./consent-metrics/ --auth=$TRANSCEND_API_KEY --start=01/01/2023 --end=03/01/2023
+ *
+ * Standard usage
+ * yarn tr-pull-consent-metrics --folder=./consent-metrics/ --auth=$TRANSCEND_API_KEY --start=01/01/2023 --end=03/01/2023
+ */
+async function main(): Promise<void> {
+  // Parse command line arguments
+  const {
+    folder = './consent-metrics/',
+    transcendUrl = 'https://api.transcend.io',
+    bin = '1d',
+    auth,
+    end,
+    start,
+  } = yargs(process.argv.slice(2));
+
+  // Parse authentication as API key or path to list of API keys
+  const apiKeyOrList = await validateTranscendAuth(auth);
+
+  // Ensure folder either does not exist or is not a file
+  if (fs.existsSync(folder) && !fs.lstatSync(folder).isDirectory()) {
+    logger.error(
+      colors.red(
+        'The provided argument "folder" was passed a file. expected: folder="./consent-metrics/"',
+      ),
+    );
+    process.exit(1);
+  }
+
+  // Validate bin
+  const parsedBin = bin as ConsentManagerMetricBin;
+  if (!Object.values(ConsentManagerMetricBin).includes(parsedBin)) {
+    logger.error(
+      colors.red(
+        `Failed to parse argument "bin" with value "${bin}"\n` +
+          `Expected one of: \n${Object.values(ConsentManagerMetricBin).join(
+            '\n',
+          )}`,
+      ),
+    );
+    process.exit(1);
+  }
+
+  // Parse the dates
+  const startDate = new Date(start);
+  const endDate = end ? new Date(end) : new Date();
+  if (Number.isNaN(startDate.getTime())) {
+    logger.error(
+      colors.red(
+        `Start date provided is invalid date. Got --start="${start}" expected --start="01/01/2023"`,
+      ),
+    );
+    process.exit(1);
+  }
+  if (Number.isNaN(endDate.getTime())) {
+    logger.error(
+      colors.red(
+        `End date provided is invalid date. Got --end="${end}" expected --end="01/01/2023"`,
+      ),
+    );
+    process.exit(1);
+  }
+  if (startDate > endDate) {
+    logger.error(
+      colors.red(
+        `Got a start date "${startDate.toISOString()}" that was larger than the end date "${endDate.toISOString()}". ` +
+          'Start date must be before end date.',
+      ),
+    );
+    process.exit(1);
+  }
+
+  // Create the folder if it does not exist
+  if (!existsSync(folder)) {
+    mkdirSync(folder);
+  }
+
+  logger.info(
+    colors.magenta(
+      `Pulling consent metrics from start=${startDate.toString()} to end=${endDate.toISOString()}`,
+    ),
+  );
+
+  // Sync to Disk
+  if (typeof apiKeyOrList === 'string') {
+    try {
+      // Create a GraphQL client
+      const client = buildTranscendGraphQLClient(transcendUrl, apiKeyOrList);
+
+      // Pull the metrics
+      const configuration = await pullConsentManagerMetrics(client, {
+        bin: parsedBin,
+        start: startDate,
+        end: endDate,
+      });
+
+      // Write to file
+      Object.entries(configuration).forEach(([metricName, metrics]) => {
+        const file = join(folder, `${metricName}.csv`);
+        logger.info(
+          colors.magenta(`Writing configuration to file "${file}"...`),
+        );
+        console.log(file);
+        console.log(metrics);
+        writeCsv(file, metrics);
+      });
+    } catch (err) {
+      logger.error(
+        colors.red(`An error occurred syncing the schema: ${err.message}`),
+      );
+      process.exit(1);
+    }
+
+    // Indicate success
+    logger.info(
+      colors.green(
+        `Successfully synced consent metrics to disk in folder "${folder}"! View at ${ADMIN_DASH_INTEGRATIONS}`,
+      ),
+    );
+  } else {
+    const encounteredErrors: string[] = [];
+    await mapSeries(apiKeyOrList, async (apiKey, ind) => {
+      const prefix = `[${ind}/${apiKeyOrList.length}][${apiKey.organizationName}] `;
+      logger.info(
+        colors.magenta(
+          `~~~\n\n${prefix}Attempting to pull consent metrics...\n\n~~~`,
+        ),
+      );
+
+      // Create a GraphQL client
+      const client = buildTranscendGraphQLClient(transcendUrl, apiKey.apiKey);
+
+      try {
+        const configuration = await pullConsentManagerMetrics(client, {
+          bin: parsedBin,
+          start: startDate,
+          end: endDate,
+        });
+
+        // ensure folder exists for that organization
+        const subFolder = join(folder, apiKey.organizationName);
+        if (!existsSync(subFolder)) {
+          mkdirSync(subFolder);
+        }
+
+        // Write to file
+        Object.entries(configuration).forEach(([metricName, metrics]) => {
+          const file = join(subFolder, `${metricName}.csv`);
+          logger.info(
+            colors.magenta(`Writing configuration to file "${file}"...`),
+          );
+          console.log(file);
+          console.log(metrics);
+          writeCsv(file, metrics);
+        });
+
+        logger.info(
+          colors.green(`${prefix}Successfully pulled configuration!`),
+        );
+      } catch (err) {
+        logger.error(colors.red(`${prefix}Failed to sync configuration.`));
+        encounteredErrors.push(apiKey.organizationName);
+      }
+    });
+
+    if (encounteredErrors.length > 0) {
+      logger.info(
+        colors.red(
+          `Sync encountered errors for "${encounteredErrors.join(
+            ',',
+          )}". View output above for more information, or check out ${ADMIN_DASH_INTEGRATIONS}`,
+        ),
+      );
+
+      process.exit(1);
+    }
+  }
+}
+
+main();

--- a/src/consent-manager/index.ts
+++ b/src/consent-manager/index.ts
@@ -1,2 +1,3 @@
 export * from './updateConsentManagerVersionToLatest';
 export * from './uploadDataFlowsFromCsv';
+export * from './pullConsentManagerMetrics';

--- a/src/consent-manager/pullConsentManagerMetrics.ts
+++ b/src/consent-manager/pullConsentManagerMetrics.ts
@@ -32,6 +32,8 @@ export async function pullConsentManagerMetrics(
   PRIVACY_SIGNAL_TIMESERIES: ConsentManagerMetric[];
   /** Consent changes data */
   CONSENT_CHANGES_TIMESERIES: ConsentManagerMetric[];
+  /** Consent sessions by regime */
+  CONSENT_SESSIONS_BY_REGIME: ConsentManagerMetric[];
 }> {
   // Grab the bundleId associated with this API key
   const airgapBundleId = await fetchConsentManagerId(client);
@@ -46,29 +48,40 @@ export async function pullConsentManagerMetrics(
   const endDate = end.toISOString();
 
   // Pull in the metrics
-  const [privacySignalData, consentChangesData] = await Promise.all([
-    fetchConsentManagerAnalyticsData(client, {
-      dataSource: 'PRIVACY_SIGNAL_TIMESERIES',
-      startDate,
-      endDate,
-      forceRefetch: true,
-      airgapBundleId,
-      binInterval: bin,
-      smoothTimeseries: false,
-    }),
-    fetchConsentManagerAnalyticsData(client, {
-      dataSource: 'CONSENT_CHANGES_TIMESERIES',
-      startDate,
-      endDate,
-      forceRefetch: true,
-      airgapBundleId,
-      binInterval: bin,
-      smoothTimeseries: false,
-    }),
-  ]);
+  const [privacySignalData, consentChangesData, consentSessionsByRegimeData] =
+    await Promise.all([
+      fetchConsentManagerAnalyticsData(client, {
+        dataSource: 'PRIVACY_SIGNAL_TIMESERIES',
+        startDate,
+        endDate,
+        forceRefetch: true,
+        airgapBundleId,
+        binInterval: bin,
+        smoothTimeseries: false,
+      }),
+      fetchConsentManagerAnalyticsData(client, {
+        dataSource: 'CONSENT_CHANGES_TIMESERIES',
+        startDate,
+        endDate,
+        forceRefetch: true,
+        airgapBundleId,
+        binInterval: bin,
+        smoothTimeseries: false,
+      }),
+      fetchConsentManagerAnalyticsData(client, {
+        dataSource: 'CONSENT_SESSIONS_BY_REGIME',
+        startDate,
+        endDate,
+        forceRefetch: true,
+        airgapBundleId,
+        binInterval: bin,
+        smoothTimeseries: false,
+      }),
+    ]);
 
   return {
     PRIVACY_SIGNAL_TIMESERIES: privacySignalData,
     CONSENT_CHANGES_TIMESERIES: consentChangesData,
+    CONSENT_SESSIONS_BY_REGIME: consentSessionsByRegimeData,
   };
 }

--- a/src/consent-manager/pullConsentManagerMetrics.ts
+++ b/src/consent-manager/pullConsentManagerMetrics.ts
@@ -1,0 +1,72 @@
+import type { GraphQLClient } from 'graphql-request';
+import {
+  ConsentManagerMetric,
+  ConsentManagerMetricBin,
+  fetchConsentManagerAnalyticsData,
+  fetchConsentManagerId,
+} from '../graphql';
+
+/**
+ * Pull consent manager metrics in an organization
+ *
+ * @param client - GraphQL client
+ * @param options - Options
+ * @returns The consent manager metrics
+ */
+export async function pullConsentManagerMetrics(
+  client: GraphQLClient,
+  {
+    bin,
+    start,
+    end = new Date(),
+  }: {
+    /** Start date to pull metrics from */
+    start: Date;
+    /** End date to pull metrics from (assumes now) */
+    end?: Date;
+    /** Bin size to pull metrics */
+    bin: ConsentManagerMetricBin;
+  },
+): Promise<{
+  /** Privacy signal data */
+  PRIVACY_SIGNAL_TIMESERIES: ConsentManagerMetric[];
+  /** Consent changes data */
+  CONSENT_CHANGES_TIMESERIES: ConsentManagerMetric[];
+}> {
+  // Grab the bundleId associated with this API key
+  const airgapBundleId = await fetchConsentManagerId(client);
+
+  // convert start and end to times
+  const startTime = Math.floor(start.getTime() / 1000);
+  const endTime = Math.floor(end.getTime() / 1000);
+  if (startTime > endTime) {
+    throw new Error('Received "end" date that happened before "start" date');
+  }
+
+  // Pull in the metrics
+  const [privacySignalData, consentChangesData] = await Promise.all([
+    fetchConsentManagerAnalyticsData(client, {
+      dataSource: 'PRIVACY_SIGNAL_TIMESERIES',
+      startDate: startTime,
+      endDate: endTime,
+      forceRefetch: true,
+      airgapBundleId,
+      binInterval: bin,
+      smoothTimeseries: false,
+    }),
+    fetchConsentManagerAnalyticsData(client, {
+      dataSource: 'CONSENT_CHANGES_TIMESERIES',
+      startDate: startTime,
+      endDate: endTime,
+      forceRefetch: true,
+      airgapBundleId,
+      binInterval: bin,
+      smoothTimeseries: false,
+    }),
+  ]);
+
+  return {
+    PRIVACY_SIGNAL_TIMESERIES: privacySignalData,
+    CONSENT_CHANGES_TIMESERIES: consentChangesData,
+  };
+}

--- a/src/consent-manager/pullConsentManagerMetrics.ts
+++ b/src/consent-manager/pullConsentManagerMetrics.ts
@@ -42,13 +42,15 @@ export async function pullConsentManagerMetrics(
   if (startTime > endTime) {
     throw new Error('Received "end" date that happened before "start" date');
   }
+  const startDate = start.toISOString();
+  const endDate = end.toISOString();
 
   // Pull in the metrics
   const [privacySignalData, consentChangesData] = await Promise.all([
     fetchConsentManagerAnalyticsData(client, {
       dataSource: 'PRIVACY_SIGNAL_TIMESERIES',
-      startDate: startTime,
-      endDate: endTime,
+      startDate,
+      endDate,
       forceRefetch: true,
       airgapBundleId,
       binInterval: bin,
@@ -56,8 +58,8 @@ export async function pullConsentManagerMetrics(
     }),
     fetchConsentManagerAnalyticsData(client, {
       dataSource: 'CONSENT_CHANGES_TIMESERIES',
-      startDate: startTime,
-      endDate: endTime,
+      startDate,
+      endDate,
       forceRefetch: true,
       airgapBundleId,
       binInterval: bin,

--- a/src/graphql/fetchConsentManagerId.ts
+++ b/src/graphql/fetchConsentManagerId.ts
@@ -239,10 +239,10 @@ export async function fetchConsentManagerAnalyticsData(
   input: {
     /** Data source */
     dataSource: 'PRIVACY_SIGNAL_TIMESERIES' | 'CONSENT_CHANGES_TIMESERIES'; // FIXME
-    /** Start date */
-    startDate: number;
-    /** End date */
-    endDate: number;
+    /** Start date, in ISO string format */
+    startDate: string;
+    /** End date, in ISO string format */
+    endDate: string;
     /** Force refetching */
     forceRefetch?: boolean;
     /** Airgap bundle ID */

--- a/src/graphql/fetchConsentManagerId.ts
+++ b/src/graphql/fetchConsentManagerId.ts
@@ -208,7 +208,6 @@ export async function fetchConsentManagerExperiences(
 
 /**
  * The allowed bin sizes for pulling consent metrics
- * FIXME
  */
 export enum ConsentManagerMetricBin {
   Hourly = '1h',
@@ -238,7 +237,10 @@ export async function fetchConsentManagerAnalyticsData(
   client: GraphQLClient,
   input: {
     /** Data source */
-    dataSource: 'PRIVACY_SIGNAL_TIMESERIES' | 'CONSENT_CHANGES_TIMESERIES'; // FIXME
+    dataSource:
+      | 'PRIVACY_SIGNAL_TIMESERIES'
+      | 'CONSENT_CHANGES_TIMESERIES'
+      | 'CONSENT_SESSIONS_BY_REGIME';
     /** Start date, in ISO string format */
     startDate: string;
     /** End date, in ISO string format */

--- a/src/graphql/fetchConsentManagerId.ts
+++ b/src/graphql/fetchConsentManagerId.ts
@@ -19,6 +19,7 @@ import {
   FETCH_CONSENT_MANAGER,
   EXPERIENCES,
   PURPOSES,
+  CONSENT_MANAGER_ANALYTICS_DATA,
 } from './gqls';
 import { makeGraphQLRequest } from './makeGraphQLRequest';
 
@@ -203,4 +204,65 @@ export async function fetchConsentManagerExperiences(
   } while (shouldContinue);
 
   return experiences;
+}
+
+/**
+ * The allowed bin sizes for pulling consent metrics
+ * FIXME
+ */
+export enum ConsentManagerMetricBin {
+  Hourly = '1h',
+  Daily = '1d',
+}
+
+export interface ConsentManagerMetric {
+  /** Name of metric */
+  name: string;
+  /** The metrics */
+  points: {
+    /** Key of metric */
+    key: string;
+    /** Value of metric */
+    value: string;
+  }[];
+}
+
+/**
+ * Fetch consent manager analytics data
+ *
+ * @param client - GraphQL client
+ * @param input - Input for fetching data
+ * @returns Consent manager purposes in the organization
+ */
+export async function fetchConsentManagerAnalyticsData(
+  client: GraphQLClient,
+  input: {
+    /** Data source */
+    dataSource: 'PRIVACY_SIGNAL_TIMESERIES' | 'CONSENT_CHANGES_TIMESERIES'; // FIXME
+    /** Start date */
+    startDate: number;
+    /** End date */
+    endDate: number;
+    /** Force refetching */
+    forceRefetch?: boolean;
+    /** Airgap bundle ID */
+    airgapBundleId: string;
+    /** Bin interval */
+    binInterval: ConsentManagerMetricBin;
+    /** Whether or not to smooth the time series */
+    smoothTimeseries: false;
+  },
+): Promise<ConsentManagerMetric[]> {
+  const {
+    analyticsData: { series },
+  } = await makeGraphQLRequest<{
+    /** Analytics data response */
+    analyticsData: {
+      /** Consent manager metrics */
+      series: ConsentManagerMetric[];
+    };
+  }>(client, CONSENT_MANAGER_ANALYTICS_DATA, {
+    input,
+  });
+  return series;
 }

--- a/src/graphql/gqls/consentManagerMetrics.ts
+++ b/src/graphql/gqls/consentManagerMetrics.ts
@@ -1,0 +1,15 @@
+import { gql } from 'graphql-request';
+
+export const CONSENT_MANAGER_ANALYTICS_DATA = gql`
+  query TranscendCliConsentManagerAnalyticsData($input: AnalyticsInput!) {
+    analyticsData(input: $input) {
+      series {
+        name
+        points {
+          key
+          value
+        }
+      }
+    }
+  }
+`;

--- a/src/graphql/gqls/index.ts
+++ b/src/graphql/gqls/index.ts
@@ -15,6 +15,7 @@ export * from './RequestEnricher';
 export * from './RequestDataSilo';
 export * from './attribute';
 export * from './consentManager';
+export * from './consentManagerMetrics';
 export * from './businessEntity';
 export * from './action';
 export * from './privacyCenter';

--- a/yarn.lock
+++ b/yarn.lock
@@ -459,6 +459,7 @@ __metadata:
     tr-manual-enrichment-push-identifiers: ./build/cli-manual-enrichment-push-identifiers.js
     tr-mark-request-data-silos-completed: ./build/cli-mark-request-data-silos-completed.js
     tr-pull: ./build/cli-pull.js
+    tr-pull-consent-metrics: ./build/cli-pull-consent-metrics.js
     tr-push: ./build/cli-push.js
     tr-request-approve: ./build/cli-request-approve.js
     tr-request-cancel: ./build/cli-request-cancel.js


### PR DESCRIPTION
- closes https://transcend.height.app/T-26221

### tr-pull-consent-metrics

This command allows for pulling consent manager metrics for a Transcend account, or a set of Transcend accounts.

#### Authentication

In order to use this cli, you will first need to generate an API key on the Transcend Admin Dashboard (https://app.transcend.io/infrastructure/api-keys).

The API key must have the following scopes:

- "View Consent Manager"

#### Arguments

| Argument     | Description                                                                   | Type                    | Default                  | Required |
| ------------ | ----------------------------------------------------------------------------- | ----------------------- | ------------------------ | -------- |
| auth         | The Transcend API key with the scopes necessary for the command.              | string                  | N/A                      | true     |
| start        | The start date to pull metrics from.                                          | string - date           | N/A                      | true     |
| end          | The end date to pull metrics until.                                           | string - date           | now()                    | true     |
| folder       | The folder to save metrics to                                                 | string - path           | ./consent-metrics/       | false    |
| bin          | The bin metric when pulling data (1h or 1d)                                   | ConsentManagerMetricBin | 1d                       | false    |
| transcendUrl | URL of the Transcend backend. Use https://api.us.transcend.io for US hosting. | string - URL            | https://api.transcend.io | false    |

#### Usage

```sh
yarn tr-pull-consent-metrics --auth=$TRANSCEND_API_KEY --start=01/01/2023
```

Specifying the backend URL, needed for US hosted backend infrastructure.

```sh
yarn tr-pull-consent-metrics --auth=$TRANSCEND_API_KEY --start=01/01/2023 --transcendUrl=https://api.us.transcend.io
```

Pull start and end date explicitly

```sh
yarn tr-pull-consent-metrics --auth=$TRANSCEND_API_KEY --start=01/01/2023 --end=03/01/2023
```

Save to an explicit folder

```sh
yarn tr-pull-consent-metrics --auth=$TRANSCEND_API_KEY --start=01/01/2023 --end=03/01/2023 --folder=./my-folder/
```

Bin data hourly vs daily

```sh
yarn tr-pull-consent-metrics --auth=$TRANSCEND_API_KEY --start=01/01/2023 --bin=1h
```

This generates the following files:
<img width="434" alt="Screenshot 2023-07-10 at 4 25 46 PM" src="https://github.com/transcend-io/cli/assets/10264973/365b8040-a2ae-465b-9092-0234634cc066">
