### PR TITLE
New cli command `yarn tr-build-xdi-sync-endpoint` can generate XDI  sync endpoint HTML file

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -69,5 +69,7 @@
     "uspapi",
     "yaml",
     "yarnpkg"
-  ]
+  ],
+  "javascript.preferences.importModuleSpecifier": "relative",
+  "typescript.preferences.importModuleSpecifier": "relative"
 }

--- a/README.md
+++ b/README.md
@@ -1191,31 +1191,31 @@ The API key must have the following scopes:
 #### Usage
 
 ```sh
-yarn tr-manual-enrichment-push-identifiers --auth=$TRANSCEND_API_KEY
+yarn tr-manual-enrichment-pull-identifiers --auth=$TRANSCEND_API_KEY
 ```
 
 Pull to a specific file location
 
 ```sh
-yarn tr-manual-enrichment-push-identifiers --auth=$TRANSCEND_API_KEY --file=/Users/transcend/Desktop/test.csv
+yarn tr-manual-enrichment-pull-identifiers --auth=$TRANSCEND_API_KEY --file=/Users/transcend/Desktop/test.csv
 ```
 
 For specific types of requests
 
 ```sh
-yarn tr-manual-enrichment-push-identifiers --auth=$TRANSCEND_API_KEY --actions=ACCESS,ERASURE
+yarn tr-manual-enrichment-pull-identifiers --auth=$TRANSCEND_API_KEY --actions=ACCESS,ERASURE
 ```
 
 For US hosted infrastructure
 
 ```sh
-yarn tr-manual-enrichment-push-identifiers --auth=$TRANSCEND_API_KEY --transcendUrl=https://api.us.transcend.io
+yarn tr-manual-enrichment-pull-identifiers --auth=$TRANSCEND_API_KEY --transcendUrl=https://api.us.transcend.io
 ```
 
 With specific concurrency
 
 ```sh
-yarn tr-manual-enrichment-push-identifiers --auth=$TRANSCEND_API_KEY --concurrency=200
+yarn tr-manual-enrichment-pull-identifiers --auth=$TRANSCEND_API_KEY --concurrency=200
 ```
 
 ### tr-manual-enrichment-push-identifiers

--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@
     - [Authentication](#authentication-18)
     - [Arguments](#arguments-18)
     - [Usage](#usage-19)
+  - [tr-build-xdi-sync-endpoint](#tr-build-xdi-sync-endpoint)
+    - [Authentication](#authentication-19)
+    - [Arguments](#arguments-19)
+    - [Usage](#usage-20)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -118,8 +122,10 @@ yarn tr-mark-request-data-silos-completed --auth=$TRANSCEND_API_KEY
 yarn tr-skip-request-data-silos --auth=$TRANSCEND_API_KEY
 yarn tr-retry-request-data-silos --auth=$TRANSCEND_API_KEY
 yarn tr-update-consent-manager --auth=$TRANSCEND_API_KEY
+yarn tr-pull-consent-metrics --auth=$TRANSCEND_API_KEY
 yarn tr-upload-data-flows-from-csv --auth=$TRANSCEND_API_KEY
 yarn tr-generate-api-keys --auth=$TRANSCEND_API_KEY
+yarn tr-build-xdi-sync-endpoint --auth=$TRANSCEND_API_KEY
 ```
 
 or
@@ -144,8 +150,11 @@ tr-mark-request-data-silos-completed --auth=$TRANSCEND_API_KEY
 tr-skip-request-data-silos --auth=$TRANSCEND_API_KEY
 tr-retry-request-data-silos --auth=$TRANSCEND_API_KEY
 tr-update-consent-manager --auth=$TRANSCEND_API_KEY
+tr-pull-consent-metrics --auth=$TRANSCEND_API_KEY
 tr-upload-data-flows-from-csv --auth=$TRANSCEND_API_KEY
 tr-generate-api-keys --auth=$TRANSCEND_API_KEY
+tr-build-xdi-sync-endpoint --auth=$TRANSCEND_API_KEY
+
 ```
 
 alternatively, you can install the cli globally on your machine:
@@ -1626,4 +1635,74 @@ Throw error if an API key already exists with that title, default behavior is to
 yarn tr-generate-api-keys  --email=test@transcend.io --password=$TRANSCEND_PASSWORD \
    --scopes="View Email Templates,View Data Map" --apiKeyTitle="CLI Usage Cross Instance Sync" -file=./working/auth.json \
    --deleteExistingApiKey=false
+```
+
+### tr-build-xdi-sync-endpoint
+
+This command allows for building of the [XDI Sync Endpoint](<https://docs.transcend.io/docs/consent/reference/xdi#addxdihostscript(standalone)>) across a set of Transcend accounts.
+
+#### Authentication
+
+In order to use this cli, you will first need to generate an API key on the Transcend Admin Dashboard (https://app.transcend.io/infrastructure/api-keys) or by using the `yarn tr-generate-api-keys` command above.
+
+The API key must have the following scopes:
+
+- "View Consent Manager"
+
+#### Arguments
+
+| Argument           | Description                                                                                               | Type               | Default                  | Required |
+| ------------------ | --------------------------------------------------------------------------------------------------------- | ------------------ | ------------------------ | -------- |
+| auth               | The Transcend API key with the scopes necessary for the command.                                          | string             | N/A                      | true     |
+| xdiLocation        | The location of the XDI that will be loaded by the generated sync endpoint. Typically this ends in xdi.js | string             | N/A                      | true     |
+| file               | The HTML file path where the sync endpoint should be written.                                             | string - file-path | ./sync-endpoint.html     | false    |
+| removeIpAddresses  | When true, remove IP addresses from the domain list                                                       | boolean            | true                     | false    |
+| domainBlockList    | The set of domains that should be excluded from the sync endpoint                                         | string[]           | localhost                | false    |
+| xdiAllowedCommands | The allowed set of XDI commands                                                                           | string             | ConsentManager:Sync      | false    |
+| transcendUrl       | URL of the Transcend backend. Use https://api.us.transcend.io for US hosting.                             | string - URL       | https://api.transcend.io | false    |
+
+#### Usage
+
+```sh
+yarn tr-build-xdi-sync-endpoint --auth=$TRANSCEND_API_KEY --xdiLocation=https://cdn.your-site.com/xdi.js
+```
+
+Specifying the backend URL, needed for US hosted backend infrastructure.
+
+```sh
+yarn tr-build-xdi-sync-endpoint --auth=$TRANSCEND_API_KEY --xdiLocation=https://cdn.your-site.com/xdi.js --transcendUrl=https://api.us.transcend.io
+```
+
+Configuring across multiple Transcend Instances:
+
+```sh
+# Pull down API keys across all Transcend instances
+yarn tr-generate-api-keys --email=$TRANSCEND_EMAIL --password=$TRANSCEND_PASSWORD --transcendUrl=https://api.us.transcend.io --scopes="View Consent Manager" --apiKeyTitle="[cli][$TRANSCEND_EMAIL] XDI Endpoint Construction" --file=./api-keys.json --parentOrganizationId=1821d872-6114-406e-90c3-73b4d5e246cf
+
+# Path list of API keys as authentication
+yarn tr-build-xdi-sync-endpoint --auth=./api-keys.json --xdiLocation=https://cdn.your-site.com/xdi.js --transcendUrl=https://api.us.transcend.io
+```
+
+Pull to specific file location
+
+```sh
+yarn tr-build-xdi-sync-endpoint --auth=$TRANSCEND_API_KEY --xdiLocation=https://cdn.your-site.com/xdi.js --file=./my-folder/sync-endpoint.html
+```
+
+Don't filter out regular expressions
+
+```sh
+yarn tr-build-xdi-sync-endpoint --auth=$TRANSCEND_API_KEY --xdiLocation=https://cdn.your-site.com/xdi.js --removeIpAddresses=false
+```
+
+Filter out certain domains that should not be included in the sync endpoint definition
+
+```sh
+yarn tr-build-xdi-sync-endpoint --auth=$TRANSCEND_API_KEY --xdiLocation=https://cdn.your-site.com/xdi.js --domainBlockList=ignored.com,localhost
+```
+
+Override XDI allowed commands
+
+```sh
+yarn tr-build-xdi-sync-endpoint --auth=$TRANSCEND_API_KEY --xdiLocation=https://cdn.your-site.com/xdi.js --xdiAllowedCommands="ExtractIdentifiers:Simple"
 ```

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "license": "MIT",
   "main": "build/index",
   "bin": {
+    "tr-build-xdi-sync-endpoint": "./build/cli-build-xdi-sync-endpoint.js",
     "tr-cron-mark-identifiers-completed": "./build/cli-cron-mark-identifiers-completed.js",
     "tr-cron-pull-identifiers": "./build/cli-cron-pull-identifiers.js",
     "tr-discover-silos": "./build/cli-discover-silos.js",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/cli",
   "description": "Small package containing useful typescript utilities.",
-  "version": "4.64.0",
+  "version": "4.65.0",
   "homepage": "https://github.com/transcend-io/cli",
   "repository": {
     "type": "git",

--- a/src/api-keys/generateCrossAccountApiKeys.ts
+++ b/src/api-keys/generateCrossAccountApiKeys.ts
@@ -11,6 +11,7 @@ import { ScopeName } from '@transcend-io/privacy-types';
 import colors from 'colors';
 import { StoredApiKey } from '../codecs';
 import { logger } from '../logger';
+import { DEFAULT_TRANSCEND_API } from '../constants';
 
 export interface ApiKeyGenerateError {
   /** Name of instance */
@@ -35,7 +36,7 @@ export async function generateCrossAccountApiKeys({
   parentOrganizationId,
   deleteExistingApiKey = true,
   createNewApiKey = true,
-  transcendUrl = 'https://api.transcend.io',
+  transcendUrl = DEFAULT_TRANSCEND_API,
 }: {
   /** Email address of user generating API keys */
   email: string;

--- a/src/cli-build-xdi-sync-endpoint.ts
+++ b/src/cli-build-xdi-sync-endpoint.ts
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+
+import yargs from 'yargs-parser';
+import { logger } from './logger';
+import colors from 'colors';
+import { writeFileSync } from 'fs';
+import { validateTranscendAuth } from './api-keys';
+import { DEFAULT_TRANSCEND_API } from './constants';
+import { buildXdiSyncEndpoint } from './consent-manager';
+import { splitCsvToList } from './requests';
+
+/**
+ * Build the Transcend Consent Manager XDI sync endpoint
+ *
+ * @see https://docs.transcend.io/docs/consent/reference/xdi#addxdihostscript(standalone)
+ *
+ * Dev Usage:
+ * yarn ts-node ./src/cli-build-xdi-sync-endpoint.ts --xdiLocation=https://cdn.your-site.com/xdi.js
+ *
+ * Standard usage
+ * yarn tr-build-xdi-sync-endpoint --xdiLocation=https://cdn.your-site.com/xdi.js
+ */
+async function main(): Promise<void> {
+  // Parse command line arguments
+  const {
+    transcendUrl = DEFAULT_TRANSCEND_API,
+    auth,
+    xdiLocation,
+    file = './sync-endpoint.html',
+    removeIpAddresses = 'true',
+    domainBlockList = '',
+    xdiAllowedCommands = 'ConsentManager:Sync',
+  } = yargs(process.argv.slice(2));
+
+  // Parse authentication as API key or path to list of API keys
+  const apiKeyOrList = await validateTranscendAuth(auth);
+
+  // Parse block list setting
+  const blockList = splitCsvToList(domainBlockList);
+
+  // Build the sync endpoint
+  const { syncGroups, html } = await buildXdiSyncEndpoint(apiKeyOrList, {
+    xdiLocation,
+    transcendUrl,
+    removeIpAddresses: removeIpAddresses === 'true',
+    domainBlockList: blockList.length > 0 ? blockList : undefined,
+    xdiAllowedCommands,
+  });
+
+  // Log success
+  logger.info(
+    colors.green(
+      `Successfully constructed sync endpoint for sync groups: ${JSON.stringify(
+        syncGroups,
+        null,
+        2,
+      )}`,
+    ),
+  );
+
+  // Write to disk
+  writeFileSync(file, html);
+  logger.info(colors.green(`Wrote configuration to file "${file}"!`));
+}
+
+main();

--- a/src/cli-cron-mark-identifiers-completed.ts
+++ b/src/cli-cron-mark-identifiers-completed.ts
@@ -5,6 +5,7 @@ import colors from 'colors';
 
 import { logger } from './logger';
 import { pushCronIdentifiersFromCsv } from './cron';
+import { DEFAULT_TRANSCEND_API } from './constants';
 
 /**
  * Mark all of the identifiers in a cron job CSV as completed.
@@ -25,7 +26,7 @@ async function main(): Promise<void> {
   // Parse command line arguments
   const {
     file = './cron-identifiers.csv',
-    transcendUrl = 'https://api.transcend.io',
+    transcendUrl = DEFAULT_TRANSCEND_API,
     auth,
     sombraAuth,
     dataSiloId,

--- a/src/cli-cron-pull-identifiers.ts
+++ b/src/cli-cron-pull-identifiers.ts
@@ -6,6 +6,7 @@ import colors from 'colors';
 import { logger } from './logger';
 import { pullCronIdentifiersToCsv } from './cron';
 import { RequestAction } from '@transcend-io/privacy-types';
+import { DEFAULT_TRANSCEND_API } from './constants';
 
 /**
  * Pull the set of active identifiers for a cron job silo.
@@ -28,7 +29,7 @@ async function main(): Promise<void> {
   // Parse command line arguments
   const {
     file = './cron-identifiers.csv',
-    transcendUrl = 'https://api.transcend.io',
+    transcendUrl = DEFAULT_TRANSCEND_API,
     auth,
     sombraAuth,
     dataSiloId,

--- a/src/cli-discover-silos.ts
+++ b/src/cli-discover-silos.ts
@@ -3,7 +3,7 @@
 import yargs from 'yargs-parser';
 import { logger } from './logger';
 import colors from 'colors';
-import { ADMIN_DASH } from './constants';
+import { ADMIN_DASH, DEFAULT_TRANSCEND_API } from './constants';
 import { SILO_DISCOVERY_FUNCTIONS } from './plugins';
 import {
   fetchActiveSiloDiscoPlugin,
@@ -31,7 +31,7 @@ async function main(): Promise<void> {
   const {
     scanPath = '.',
     ignoreDirs = '',
-    transcendUrl = 'https://api.transcend.io',
+    transcendUrl = DEFAULT_TRANSCEND_API,
     dataSiloId = '',
     fileGlobs = '',
     auth,

--- a/src/cli-generate-cross-account-api-keys.ts
+++ b/src/cli-generate-cross-account-api-keys.ts
@@ -8,6 +8,7 @@ import { ScopeName, TRANSCEND_SCOPES } from '@transcend-io/privacy-types';
 
 import { logger } from './logger';
 import { generateCrossAccountApiKeys } from './api-keys';
+import { DEFAULT_TRANSCEND_API } from './constants';
 
 const SCOPES_BY_TITLE = keyBy(
   Object.entries(TRANSCEND_SCOPES).map(([name, value]) => ({
@@ -34,7 +35,7 @@ const SCOPE_TITLES = Object.keys(SCOPES_BY_TITLE);
 async function main(): Promise<void> {
   // Parse command line arguments
   const {
-    transcendUrl = 'https://api.transcend.io',
+    transcendUrl = DEFAULT_TRANSCEND_API,
     file,
     email,
     password,

--- a/src/cli-manual-enrichment-pull-identifiers.ts
+++ b/src/cli-manual-enrichment-pull-identifiers.ts
@@ -6,6 +6,7 @@ import colors from 'colors';
 import { logger } from './logger';
 import { pullManualEnrichmentIdentifiersToCsv } from './manual-enrichment';
 import { RequestAction } from '@transcend-io/privacy-types';
+import { DEFAULT_TRANSCEND_API } from './constants';
 
 /**
  * Pull the the set of requests that actively require manual enrichment.
@@ -26,7 +27,7 @@ async function main(): Promise<void> {
   // Parse command line arguments
   const {
     file = './manual-enrichment-identifiers.csv',
-    transcendUrl = 'https://api.transcend.io',
+    transcendUrl = DEFAULT_TRANSCEND_API,
     auth,
     actions = '',
     concurrency = '100',

--- a/src/cli-manual-enrichment-push-identifiers.ts
+++ b/src/cli-manual-enrichment-push-identifiers.ts
@@ -5,6 +5,7 @@ import colors from 'colors';
 
 import { logger } from './logger';
 import { pushManualEnrichmentIdentifiersFromCsv } from './manual-enrichment';
+import { DEFAULT_TRANSCEND_API } from './constants';
 
 /**
  * Push the the set of manually enriched requests back into the Transcend dashboard
@@ -23,7 +24,7 @@ async function main(): Promise<void> {
   // Parse command line arguments
   const {
     file = './manual-enrichment-identifiers.csv',
-    transcendUrl = 'https://api.transcend.io',
+    transcendUrl = DEFAULT_TRANSCEND_API,
     auth,
     enricherId,
     sombraAuth,

--- a/src/cli-mark-request-data-silos-completed.ts
+++ b/src/cli-mark-request-data-silos-completed.ts
@@ -5,6 +5,7 @@ import colors from 'colors';
 
 import { logger } from './logger';
 import { markRequestDataSiloIdsCompleted } from './cron';
+import { DEFAULT_TRANSCEND_API } from './constants';
 
 /**
  * Given a set of Request IDs and a Data Silo ID, mark the RequestDataSilos as completed
@@ -26,7 +27,7 @@ async function main(): Promise<void> {
   // Parse command line arguments
   const {
     file = './request-identifiers.csv',
-    transcendUrl = 'https://api.transcend.io',
+    transcendUrl = DEFAULT_TRANSCEND_API,
     auth,
     dataSiloId,
   } = yargs(process.argv.slice(2)) as { [k in string]: string };

--- a/src/cli-pull-consent-metrics.ts
+++ b/src/cli-pull-consent-metrics.ts
@@ -11,7 +11,7 @@ import {
   ConsentManagerMetricBin,
 } from './graphql';
 import { validateTranscendAuth } from './api-keys';
-import { ADMIN_DASH_INTEGRATIONS } from './constants';
+import { ADMIN_DASH_INTEGRATIONS, DEFAULT_TRANSCEND_API } from './constants';
 import { pullConsentManagerMetrics } from './consent-manager';
 import { writeCsv } from './cron';
 
@@ -28,7 +28,7 @@ async function main(): Promise<void> {
   // Parse command line arguments
   const {
     folder = './consent-metrics/',
-    transcendUrl = 'https://api.transcend.io',
+    transcendUrl = DEFAULT_TRANSCEND_API,
     bin = '1d',
     auth,
     end,

--- a/src/cli-pull.ts
+++ b/src/cli-pull.ts
@@ -15,7 +15,7 @@ import {
 import { ConsentTrackerStatus } from '@transcend-io/privacy-types';
 import { validateTranscendAuth } from './api-keys';
 import { writeTranscendYaml } from './readTranscendYaml';
-import { ADMIN_DASH_INTEGRATIONS } from './constants';
+import { ADMIN_DASH_INTEGRATIONS, DEFAULT_TRANSCEND_API } from './constants';
 import { splitCsvToList } from './requests';
 
 const VALID_RESOURCES = Object.values(TranscendPullResource);
@@ -33,7 +33,7 @@ async function main(): Promise<void> {
   // Parse command line arguments
   const {
     file = './transcend.yml',
-    transcendUrl = 'https://api.transcend.io',
+    transcendUrl = DEFAULT_TRANSCEND_API,
     dataSiloIds = '',
     integrationNames = '',
     resources = DEFAULT_TRANSCEND_PULL_RESOURCES.join(','),
@@ -176,7 +176,9 @@ async function main(): Promise<void> {
           colors.green(`${prefix}Successfully pulled configuration!`),
         );
       } catch (err) {
-        logger.error(colors.red(`${prefix}Failed to sync configuration.`));
+        logger.error(
+          colors.red(`${prefix}Failed to sync configuration. - ${err.message}`),
+        );
         encounteredErrors.push(apiKey.organizationName);
       }
     });

--- a/src/cli-push.ts
+++ b/src/cli-push.ts
@@ -12,7 +12,7 @@ import {
   syncConfigurationToTranscend,
 } from './graphql';
 
-import { ADMIN_DASH_INTEGRATIONS } from './constants';
+import { ADMIN_DASH_INTEGRATIONS, DEFAULT_TRANSCEND_API } from './constants';
 import { TranscendInput } from './codecs';
 import { ObjByString } from '@transcend-io/type-utils';
 import { validateTranscendAuth, listFiles } from './api-keys';
@@ -78,7 +78,7 @@ async function main(): Promise<void> {
   // Parse command line arguments
   const {
     file = './transcend.yml',
-    transcendUrl = 'https://api.transcend.io',
+    transcendUrl = DEFAULT_TRANSCEND_API,
     auth,
     variables = '',
     pageSize = '',
@@ -110,6 +110,7 @@ async function main(): Promise<void> {
     throw new Error('No file specified!');
   }
 
+  // eslint-disable-next-line array-callback-return,consistent-return
   const transcendInputs = fileList.map((filePath) => {
     // Ensure yaml file exists on disk
     if (!existsSync(filePath)) {
@@ -139,7 +140,6 @@ async function main(): Promise<void> {
         ),
       );
       process.exit(1);
-      throw err;
     }
   });
 

--- a/src/cli-request-approve.ts
+++ b/src/cli-request-approve.ts
@@ -6,6 +6,7 @@ import colors from 'colors';
 import { logger } from './logger';
 import { RequestAction } from '@transcend-io/privacy-types';
 import { splitCsvToList, approvePrivacyRequests } from './requests';
+import { DEFAULT_TRANSCEND_API } from './constants';
 
 /**
  * Restart requests based on some filter criteria
@@ -26,7 +27,7 @@ import { splitCsvToList, approvePrivacyRequests } from './requests';
 async function main(): Promise<void> {
   // Parse command line arguments
   const {
-    transcendUrl = 'https://api.transcend.io',
+    transcendUrl = DEFAULT_TRANSCEND_API,
     auth,
     actions = '',
     silentModeBefore,

--- a/src/cli-request-cancel.ts
+++ b/src/cli-request-cancel.ts
@@ -6,6 +6,7 @@ import colors from 'colors';
 import { logger } from './logger';
 import { RequestAction, RequestStatus } from '@transcend-io/privacy-types';
 import { splitCsvToList, cancelPrivacyRequests } from './requests';
+import { DEFAULT_TRANSCEND_API } from './constants';
 
 /**
  * Cancel requests based on some filter criteria
@@ -24,7 +25,7 @@ import { splitCsvToList, cancelPrivacyRequests } from './requests';
 async function main(): Promise<void> {
   // Parse command line arguments
   const {
-    transcendUrl = 'https://api.transcend.io',
+    transcendUrl = DEFAULT_TRANSCEND_API,
     auth,
     actions = '',
     statuses = '',

--- a/src/cli-request-export.ts
+++ b/src/cli-request-export.ts
@@ -6,6 +6,7 @@ import colors from 'colors';
 import { logger } from './logger';
 import { RequestAction, RequestStatus } from '@transcend-io/privacy-types';
 import { splitCsvToList, pullRequestsToCsv } from './requests';
+import { DEFAULT_TRANSCEND_API } from './constants';
 
 /**
  * Pull down the metadata for a set of Privacy requests.
@@ -28,7 +29,7 @@ async function main(): Promise<void> {
   // Parse command line arguments
   const {
     file = './transcend-request-export.csv',
-    transcendUrl = 'https://api.transcend.io',
+    transcendUrl = DEFAULT_TRANSCEND_API,
     auth,
     actions = '',
     statuses = '',

--- a/src/cli-request-restart.ts
+++ b/src/cli-request-restart.ts
@@ -6,6 +6,7 @@ import colors from 'colors';
 import { logger } from './logger';
 import { splitCsvToList, bulkRestartRequests } from './requests';
 import { RequestAction, RequestStatus } from '@transcend-io/privacy-types';
+import { DEFAULT_TRANSCEND_API } from './constants';
 
 const ONE_MONTH = 30.5 * 24 * 60 * 60 * 1000;
 
@@ -28,7 +29,7 @@ async function main(): Promise<void> {
   // Parse command line arguments
   const {
     auth,
-    transcendUrl = 'https://api.transcend.io',
+    transcendUrl = DEFAULT_TRANSCEND_API,
     sombraAuth,
     /** Restart requests matching these request actions */
     actions,

--- a/src/cli-request-upload.ts
+++ b/src/cli-request-upload.ts
@@ -5,6 +5,7 @@ import colors from 'colors';
 
 import { logger } from './logger';
 import { splitCsvToList, uploadPrivacyRequestsFromCsv } from './requests';
+import { DEFAULT_TRANSCEND_API } from './constants';
 
 /**
  * Upload a CSV of Privacy Requests.
@@ -29,7 +30,7 @@ async function main(): Promise<void> {
   const {
     auth,
     file = './requests.csv',
-    transcendUrl = 'https://api.transcend.io',
+    transcendUrl = DEFAULT_TRANSCEND_API,
     cacheFilepath = './transcend-privacy-requests-cache.json',
     requestReceiptFolder = './privacy-request-upload-receipts',
     sombraAuth,

--- a/src/cli-retry-request-data-silos.ts
+++ b/src/cli-retry-request-data-silos.ts
@@ -6,6 +6,7 @@ import { RequestAction } from '@transcend-io/privacy-types';
 
 import { logger } from './logger';
 import { retryRequestDataSilos } from './requests';
+import { DEFAULT_TRANSCEND_API } from './constants';
 
 /**
  * Bulk wipe and retry a set of requests for a specific data silo
@@ -26,7 +27,7 @@ import { retryRequestDataSilos } from './requests';
 async function main(): Promise<void> {
   // Parse command line arguments
   const {
-    transcendUrl = 'https://api.transcend.io',
+    transcendUrl = DEFAULT_TRANSCEND_API,
     auth,
     dataSiloId,
     actions,

--- a/src/cli-skip-request-data-silos.ts
+++ b/src/cli-skip-request-data-silos.ts
@@ -5,6 +5,7 @@ import colors from 'colors';
 
 import { logger } from './logger';
 import { skipRequestDataSilos } from './requests';
+import { DEFAULT_TRANSCEND_API } from './constants';
 
 /**
  * Given a data silo ID, skip all active privacy requests that are open for that data silo
@@ -23,7 +24,7 @@ import { skipRequestDataSilos } from './requests';
 async function main(): Promise<void> {
   // Parse command line arguments
   const {
-    transcendUrl = 'https://api.transcend.io',
+    transcendUrl = DEFAULT_TRANSCEND_API,
     auth,
     dataSiloId,
   } = yargs(process.argv.slice(2)) as { [k in string]: string };

--- a/src/cli-update-consent-manager-to-latest.ts
+++ b/src/cli-update-consent-manager-to-latest.ts
@@ -8,6 +8,7 @@ import { mapSeries } from 'bluebird';
 import { logger } from './logger';
 import { updateConsentManagerVersionToLatest } from './consent-manager';
 import { validateTranscendAuth } from './api-keys';
+import { DEFAULT_TRANSCEND_API } from './constants';
 
 /**
  * Update the consent manager to latest version
@@ -23,7 +24,7 @@ import { validateTranscendAuth } from './api-keys';
 async function main(): Promise<void> {
   // Parse command line arguments
   const {
-    transcendUrl = 'https://api.transcend.io',
+    transcendUrl = DEFAULT_TRANSCEND_API,
     auth,
     deploy = 'false',
     bundleTypes = Object.values(ConsentBundleType).join(','),

--- a/src/cli-upload-data-flows-from-csv.ts
+++ b/src/cli-upload-data-flows-from-csv.ts
@@ -6,6 +6,7 @@ import colors from 'colors';
 import { logger } from './logger';
 import { uploadDataFlowsFromCsv } from './consent-manager';
 import { ConsentTrackerStatus } from '@transcend-io/privacy-types';
+import { DEFAULT_TRANSCEND_API } from './constants';
 
 /**
  * Upload a CSV of data flows
@@ -30,7 +31,7 @@ async function main(): Promise<void> {
     trackerStatus,
     classifyService = 'false',
     file = './data-flows.csv',
-    transcendUrl = 'https://api.transcend.io',
+    transcendUrl = DEFAULT_TRANSCEND_API,
   } = yargs(process.argv.slice(2)) as { [k in string]: string };
 
   // Ensure auth is passed

--- a/src/consent-manager/buildXdiSyncEndpoint.ts
+++ b/src/consent-manager/buildXdiSyncEndpoint.ts
@@ -1,0 +1,142 @@
+import colors from 'colors';
+
+import { buildTranscendGraphQLClient, fetchConsentManager } from '../graphql';
+import difference from 'lodash/difference';
+import { map } from 'bluebird';
+import { StoredApiKey } from '../codecs';
+import { DEFAULT_TRANSCEND_API } from '../constants';
+import { logger } from '../logger';
+
+/**
+ * Sync group configuration mapping
+ * e.g.
+ * {
+ *   "abdb5e78-0d69-4554-a3bd-84b72ca3b3d9": [
+ *      "test.com"
+ *   ],
+ *   "f6b3ba87-c9df-444f-b420-6fac49e35910": [
+ *     "blue.com"
+ *   ]
+ * }
+ */
+export type XdiSyncGroups = { [k in string]: string[] };
+
+/** Regular expression for IP addresses - remove these from sync endpoint */
+export const IP_ADDRESS_REGEX =
+  // eslint-disable-next-line max-len
+  /^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;
+
+/**
+ * Convert a domain to host
+ *
+ * @param domain - e.g. test.acme.com
+ * @returns Host acme.com
+ */
+const domainToHost = (domain: string): string =>
+  new URL(`https://${domain}`).hostname.split('.').slice(-2).join('.');
+
+/**
+ * Build the sync endpoint definition for a set of Transcend accounts
+ *
+ * @param apiKeys - The API keys that will be used to pull down configurations for
+ * @param options - Options
+ * @returns The XDI configuration
+ */
+export async function buildXdiSyncEndpoint(
+  apiKeys: string | StoredApiKey[],
+  {
+    xdiLocation,
+    transcendUrl = DEFAULT_TRANSCEND_API,
+    removeIpAddresses = true,
+    domainBlockList = ['localhost'],
+    xdiAllowedCommands = 'ConsentManager:Sync',
+  }: {
+    /** The file location where the XDI file is hosted */
+    xdiLocation: string;
+    /** URL of Transcend API */
+    transcendUrl?: string;
+    /** When true, remove IP addresses (defaults to true) */
+    removeIpAddresses?: boolean;
+    /** Block list of domains to omit from sync endpoint - includes `localhost` by default */
+    domainBlockList?: string[];
+    /** Allows XDI commands */
+    xdiAllowedCommands?: string;
+  },
+): Promise<{
+  /** Sync group configurations */
+  syncGroups: XdiSyncGroups;
+  /** The HTML string */
+  html: string;
+}> {
+  // Convert API keys to list
+  const apiKeysAsList = Array.isArray(apiKeys)
+    ? apiKeys
+    : [{ apiKey: apiKeys, organizationId: '', organizationName: '' }];
+
+  // Fetch configuration for each account
+  const consentManagers = await map(
+    apiKeysAsList,
+    async (apiKey) => {
+      logger.info(
+        colors.magenta(
+          `Pulling consent metadata for organization - ${apiKey.organizationName}`,
+        ),
+      );
+
+      // Create a GraphQL client
+      const client = buildTranscendGraphQLClient(transcendUrl, apiKey.apiKey);
+
+      // Grab consent manager
+      const consentManager = await fetchConsentManager(client);
+      return consentManager;
+    },
+    { concurrency: 5 },
+  );
+
+  // construct the sync groups
+  const syncGroups: XdiSyncGroups = {};
+  consentManagers.forEach((consentManager) => {
+    // grab the partition key
+    const partitionKey =
+      // take explicit key first
+      consentManager.partition?.partition ||
+      // fallback to bundle ID
+      consentManager.bundleURL.split('/').reverse()[1];
+
+    // Ensure that partition exists in the sync groups
+    if (!syncGroups[partitionKey]) {
+      syncGroups[partitionKey] = [];
+    }
+
+    // Map domain list to a host list
+    const hosts = difference(
+      consentManager.configuration.domains
+        .filter(
+          // ignore IP addresses
+          (domain) => !removeIpAddresses || !IP_ADDRESS_REGEX.test(domain),
+        )
+        .map((domain) => domainToHost(domain)),
+      // ignore block list
+      domainBlockList,
+    );
+    // merge existing sync group with hosts for this consent manager
+    syncGroups[partitionKey] = [
+      ...new Set([...(syncGroups[partitionKey] || []), ...hosts]),
+    ];
+  });
+
+  // Construct the HTML
+  const syncEndpointHtml = `
+<!DOCTYPE html>
+<script
+src="${xdiLocation}"
+data-sync-groups='${JSON.stringify(syncGroups, null, 2)}'
+data-xdi-commands="${xdiAllowedCommands}"
+></script>
+`;
+
+  return {
+    html: syncEndpointHtml,
+    syncGroups,
+  };
+}

--- a/src/consent-manager/index.ts
+++ b/src/consent-manager/index.ts
@@ -1,3 +1,4 @@
 export * from './updateConsentManagerVersionToLatest';
 export * from './uploadDataFlowsFromCsv';
 export * from './pullConsentManagerMetrics';
+export * from './buildXdiSyncEndpoint';

--- a/src/consent-manager/updateConsentManagerVersionToLatest.ts
+++ b/src/consent-manager/updateConsentManagerVersionToLatest.ts
@@ -9,6 +9,7 @@ import {
 import colors from 'colors';
 
 import { logger } from '../logger';
+import { DEFAULT_TRANSCEND_API } from '../constants';
 
 /**
  * Update the consent manager to latest version
@@ -18,7 +19,7 @@ import { logger } from '../logger';
 export async function updateConsentManagerVersionToLatest({
   auth,
   deploy = false,
-  transcendUrl = 'https://api.transcend.io',
+  transcendUrl = DEFAULT_TRANSCEND_API,
   bundleTypes = Object.values(ConsentBundleType),
 }: {
   /** Transcend API key authentication */

--- a/src/consent-manager/uploadDataFlowsFromCsv.ts
+++ b/src/consent-manager/uploadDataFlowsFromCsv.ts
@@ -10,6 +10,7 @@ import { readCsv } from '../requests/readCsv';
 import { valuesOf } from '@transcend-io/type-utils';
 import { DataFlowInput } from '../codecs';
 import { splitCsvToList } from '../requests';
+import { DEFAULT_TRANSCEND_API } from '../constants';
 
 /**
  * Minimal set required to mark as completed
@@ -64,7 +65,7 @@ export async function uploadDataFlowsFromCsv({
   trackerStatus,
   file,
   classifyService = false,
-  transcendUrl = 'https://api.transcend.io',
+  transcendUrl = DEFAULT_TRANSCEND_API,
 }: {
   /** CSV file path */
   file: string;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,5 @@
 export const ADMIN_DASH = 'https://app.transcend.io';
 
 export const ADMIN_DASH_INTEGRATIONS = `${ADMIN_DASH}/infrastructure/integrations`;
+
+export const DEFAULT_TRANSCEND_API = 'https://api.transcend.io';

--- a/src/cron/markRequestDataSiloIdsCompleted.ts
+++ b/src/cron/markRequestDataSiloIdsCompleted.ts
@@ -10,6 +10,7 @@ import {
 } from '../graphql';
 import * as t from 'io-ts';
 import cliProgress from 'cli-progress';
+import { DEFAULT_TRANSCEND_API } from '../constants';
 
 const RequestIdRow = t.type({
   'Request Id': t.string,
@@ -26,7 +27,7 @@ export async function markRequestDataSiloIdsCompleted({
   dataSiloId,
   auth,
   concurrency = 100,
-  transcendUrl = 'https://api.transcend.io',
+  transcendUrl = DEFAULT_TRANSCEND_API,
 }: {
   /** CSV file path */
   file: string;

--- a/src/cron/pullCronIdentifiersToCsv.ts
+++ b/src/cron/pullCronIdentifiersToCsv.ts
@@ -8,6 +8,7 @@ import {
 import { RequestAction } from '@transcend-io/privacy-types';
 import { writeCsv } from './writeCsv';
 import { logger } from '../logger';
+import { DEFAULT_TRANSCEND_API } from '../constants';
 
 /**
  * Pull the set of cron job identifiers to CSV
@@ -21,7 +22,7 @@ export async function pullCronIdentifiersToCsv({
   sombraAuth,
   requestType,
   pageLimit = 100,
-  transcendUrl = 'https://api.transcend.io',
+  transcendUrl = DEFAULT_TRANSCEND_API,
 }: {
   /** CSV file path */
   file: string;

--- a/src/cron/pushCronIdentifiersFromCsv.ts
+++ b/src/cron/pushCronIdentifiersFromCsv.ts
@@ -7,6 +7,7 @@ import {
 } from './markCronIdentifierCompleted';
 import { logger } from '../logger';
 import { readCsv } from '../requests';
+import { DEFAULT_TRANSCEND_API } from '../constants';
 
 /**
  * Given a CSV of cron job outputs, mark all requests as completed in Transcend
@@ -20,7 +21,7 @@ export async function pushCronIdentifiersFromCsv({
   auth,
   sombraAuth,
   concurrency = 100,
-  transcendUrl = 'https://api.transcend.io',
+  transcendUrl = DEFAULT_TRANSCEND_API,
 }: {
   /** CSV file path */
   file: string;

--- a/src/graphql/fetchConsentManagerId.ts
+++ b/src/graphql/fetchConsentManagerId.ts
@@ -53,6 +53,11 @@ export interface ConsentManager {
     /** Partition parameter */
     partition: string;
   };
+  /** When using a custom partition, this is the partition value */
+  partition?: {
+    /** Partition value */
+    partition: string;
+  };
 }
 
 /**

--- a/src/graphql/gqls/consentManager.ts
+++ b/src/graphql/gqls/consentManager.ts
@@ -203,6 +203,9 @@ export const FETCH_CONSENT_MANAGER = gql`
           syncGroups
           partition
         }
+        partition {
+          partition
+        }
       }
     }
   }

--- a/src/graphql/syncDataSilos.ts
+++ b/src/graphql/syncDataSilos.ts
@@ -632,7 +632,7 @@ export async function syncDataSilo(
     });
     existingDataSilo = updateDataSilo.dataSilo;
   } else {
-    // FIXME use createDataSilos
+    // TODO: https://transcend.height.app/T-26999 - remove this, use createDataSilos
     const { connectDataSilo } = await makeGraphQLRequest<{
       /** Mutation result */
       connectDataSilo: {

--- a/src/manual-enrichment/pullManualEnrichmentIdentifiersToCsv.ts
+++ b/src/manual-enrichment/pullManualEnrichmentIdentifiersToCsv.ts
@@ -14,6 +14,7 @@ import { map } from 'bluebird';
 import { RequestAction, RequestStatus } from '@transcend-io/privacy-types';
 import { writeCsv } from '../cron/writeCsv';
 import { logger } from '../logger';
+import { DEFAULT_TRANSCEND_API } from '../constants';
 
 export interface PrivacyRequestWithIdentifiers extends PrivacyRequest {
   /** Request Enrichers */
@@ -32,7 +33,7 @@ export async function pullManualEnrichmentIdentifiersToCsv({
   auth,
   requestActions,
   concurrency = 100,
-  transcendUrl = 'https://api.transcend.io',
+  transcendUrl = DEFAULT_TRANSCEND_API,
 }: {
   /** CSV file path */
   file: string;

--- a/src/manual-enrichment/pushManualEnrichmentIdentifiersFromCsv.ts
+++ b/src/manual-enrichment/pushManualEnrichmentIdentifiersFromCsv.ts
@@ -7,6 +7,7 @@ import {
   EnrichPrivacyRequest,
 } from './enrichPrivacyRequest';
 import { readCsv } from '../requests';
+import { DEFAULT_TRANSCEND_API } from '../constants';
 
 /**
  * Push a CSV of enriched requests back into Transcend
@@ -20,7 +21,7 @@ export async function pushManualEnrichmentIdentifiersFromCsv({
   sombraAuth,
   enricherId,
   concurrency = 100,
-  transcendUrl = 'https://api.transcend.io',
+  transcendUrl = DEFAULT_TRANSCEND_API,
 }: {
   /** CSV file path */
   file: string;

--- a/src/requests/approvePrivacyRequests.ts
+++ b/src/requests/approvePrivacyRequests.ts
@@ -10,6 +10,7 @@ import {
   APPROVE_PRIVACY_REQUEST,
 } from '../graphql';
 import cliProgress from 'cli-progress';
+import { DEFAULT_TRANSCEND_API } from '../constants';
 
 /**
  * Approve a set of privacy requests
@@ -22,7 +23,7 @@ export async function approvePrivacyRequests({
   auth,
   silentModeBefore,
   concurrency = 100,
-  transcendUrl = 'https://api.transcend.io',
+  transcendUrl = DEFAULT_TRANSCEND_API,
 }: {
   /** The request actions that should be restarted */
   requestActions: RequestAction[];

--- a/src/requests/bulkRestartRequests.ts
+++ b/src/requests/bulkRestartRequests.ts
@@ -16,6 +16,7 @@ import {
 } from '../graphql';
 import { extractClientError } from './extractClientError';
 import { SuccessfulRequest } from './constants';
+import { DEFAULT_TRANSCEND_API } from '../constants';
 
 /** Minimal state we need to keep a list of requests */
 const ErrorRequest = t.intersection([
@@ -45,7 +46,7 @@ export async function bulkRestartRequests({
   sombraAuth,
   requestActions,
   requestStatuses,
-  transcendUrl = 'https://api.transcend.io',
+  transcendUrl = DEFAULT_TRANSCEND_API,
   requestIds = [],
   createdAt = new Date(),
   markSilent,

--- a/src/requests/cancelPrivacyRequests.ts
+++ b/src/requests/cancelPrivacyRequests.ts
@@ -12,6 +12,7 @@ import {
   Template,
 } from '../graphql';
 import cliProgress from 'cli-progress';
+import { DEFAULT_TRANSCEND_API } from '../constants';
 
 /**
  * Cancel a set of privacy requests
@@ -36,7 +37,7 @@ export async function cancelPrivacyRequests({
     RequestStatus.SecondaryApproving,
   ],
   concurrency = 100,
-  transcendUrl = 'https://api.transcend.io',
+  transcendUrl = DEFAULT_TRANSCEND_API,
 }: {
   /** The request actions that should be restarted */
   requestActions: RequestAction[];

--- a/src/requests/pullRequestsToCsv.ts
+++ b/src/requests/pullRequestsToCsv.ts
@@ -12,6 +12,7 @@ import groupBy from 'lodash/groupBy';
 import { RequestAction, RequestStatus } from '@transcend-io/privacy-types';
 import { writeCsv } from '../cron/writeCsv';
 import { logger } from '../logger';
+import { DEFAULT_TRANSCEND_API } from '../constants';
 
 export interface ExportedPrivacyRequest extends PrivacyRequest {
   /** Request identifiers */
@@ -29,7 +30,7 @@ export async function pullRequestsToCsv({
   actions = [],
   statuses = [],
   pageLimit = 100,
-  transcendUrl = 'https://api.transcend.io',
+  transcendUrl = DEFAULT_TRANSCEND_API,
   createdAtBefore,
   createdAtAfter,
   showTests,

--- a/src/requests/retryRequestDataSilos.ts
+++ b/src/requests/retryRequestDataSilos.ts
@@ -10,6 +10,7 @@ import {
   buildTranscendGraphQLClient,
 } from '../graphql';
 import cliProgress from 'cli-progress';
+import { DEFAULT_TRANSCEND_API } from '../constants';
 
 /**
  * Retry a set of RequestDataSilos
@@ -22,7 +23,7 @@ export async function retryRequestDataSilos({
   dataSiloId,
   auth,
   concurrency = 20,
-  transcendUrl = 'https://api.transcend.io',
+  transcendUrl = DEFAULT_TRANSCEND_API,
 }: {
   /** The request actions that should be restarted */
   requestActions: RequestAction[];

--- a/src/requests/skipRequestDataSilos.ts
+++ b/src/requests/skipRequestDataSilos.ts
@@ -12,6 +12,7 @@ import {
   RequestDataSiloStatus,
   RequestStatus,
 } from '@transcend-io/privacy-types';
+import { DEFAULT_TRANSCEND_API } from '../constants';
 
 /**
  * Given a data silo ID, mark all open request data silos as skipped
@@ -23,7 +24,7 @@ export async function skipRequestDataSilos({
   dataSiloId,
   auth,
   concurrency = 100,
-  transcendUrl = 'https://api.transcend.io',
+  transcendUrl = DEFAULT_TRANSCEND_API,
 }: {
   /** Transcend API key authentication */
   auth: string;

--- a/src/requests/uploadPrivacyRequestsFromCsv.ts
+++ b/src/requests/uploadPrivacyRequestsFromCsv.ts
@@ -22,6 +22,7 @@ import { mapColumnsToIdentifiers } from './mapColumnsToIdentifiers';
 import { mapCsvRowsToRequestInputs } from './mapCsvRowsToRequestInputs';
 import { filterRows } from './filterRows';
 import { extractClientError } from './extractClientError';
+import { DEFAULT_TRANSCEND_API } from '../constants';
 
 /**
  * Upload a set of privacy requests from CSV
@@ -36,7 +37,7 @@ export async function uploadPrivacyRequestsFromCsv({
   sombraAuth,
   concurrency = 100,
   defaultPhoneCountryCode = '1', // USA
-  transcendUrl = 'https://api.transcend.io',
+  transcendUrl = DEFAULT_TRANSCEND_API,
   attributes = [],
   emailIsVerified = true,
   skipFilterStep = false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -451,6 +451,7 @@ __metadata:
     typescript: ^5.0.4
     yargs-parser: ^21.1.1
   bin:
+    tr-build-xdi-sync-endpoint: ./build/cli-build-xdi-sync-endpoint.js
     tr-cron-mark-identifiers-completed: ./build/cli-cron-mark-identifiers-completed.js
     tr-cron-pull-identifiers: ./build/cli-cron-pull-identifiers.js
     tr-discover-silos: ./build/cli-discover-silos.js


### PR DESCRIPTION
## Related Issues

- closes https://transcend.height.app/T-27000

This command allows for building of the [XDI Sync Endpoint](<https://docs.transcend.io/docs/consent/reference/xdi#addxdihostscript(standalone)>) across a set of Transcend accounts.

#### Authentication

In order to use this cli, you will first need to generate an API key on the Transcend Admin Dashboard (https://app.transcend.io/infrastructure/api-keys) or by using the `yarn tr-generate-api-keys` command above.

The API key must have the following scopes:

- "View Consent Manager"

#### Arguments

| Argument           | Description                                                                                               | Type               | Default                  | Required |
| ------------------ | --------------------------------------------------------------------------------------------------------- | ------------------ | ------------------------ | -------- |
| auth               | The Transcend API key with the scopes necessary for the command.                                          | string             | N/A                      | true     |
| xdiLocation        | The location of the XDI that will be loaded by the generated sync endpoint. Typically this ends in xdi.js | string             | N/A                      | true     |
| file               | The HTML file path where the sync endpoint should be written.                                             | string - file-path | ./sync-endpoint.html     | false    |
| removeIpAddresses  | When true, remove IP addresses from the domain list                                                       | boolean            | true                     | false    |
| domainBlockList    | The set of domains that should be excluded from the sync endpoint                                         | string[]           | localhost                | false    |
| xdiAllowedCommands | The allowed set of XDI commands                                                                           | string             | ConsentManager:Sync      | false    |
| transcendUrl       | URL of the Transcend backend. Use https://api.us.transcend.io for US hosting.                             | string - URL       | https://api.transcend.io | false    |

domainBlockList = '',
xdiAllowedCommands = 'ConsentManager:Sync',

#### Usage

```sh
yarn tr-build-xdi-sync-endpoint --auth=$TRANSCEND_API_KEY --xdiLocation=https://cdn.your-site.com/xdi.js
```

Specifying the backend URL, needed for US hosted backend infrastructure.

```sh
yarn tr-build-xdi-sync-endpoint --auth=$TRANSCEND_API_KEY --xdiLocation=https://cdn.your-site.com/xdi.js --transcendUrl=https://api.us.transcend.io
```

Configuring across multiple Transcend Instances:

```sh
# Pull down API keys across all Transcend instances
yarn tr-generate-api-keys --email=$TRANSCEND_EMAIL --password=$TRANSCEND_PASSWORD --transcendUrl=https://api.us.transcend.io --scopes="View Consent Manager" --apiKeyTitle="[cli][$TRANSCEND_EMAIL] XDI Endpoint Construction" --file=./api-keys.json --parentOrganizationId=1821d872-6114-406e-90c3-73b4d5e246cf

# Path list of API keys as authentication
yarn tr-build-xdi-sync-endpoint --auth=./api-keys.json --xdiLocation=https://cdn.your-site.com/xdi.js --transcendUrl=https://api.us.transcend.io
```

Pull to specific file location

```sh
yarn tr-build-xdi-sync-endpoint --auth=$TRANSCEND_API_KEY --xdiLocation=https://cdn.your-site.com/xdi.js --file=./my-folder/sync-endpoint.html
```

Don't filter out regular expressions

```sh
yarn tr-build-xdi-sync-endpoint --auth=$TRANSCEND_API_KEY --xdiLocation=https://cdn.your-site.com/xdi.js --removeIpAddresses=false
```

Filter out certain domains that should not be included in the sync endpoint definition

```sh
yarn tr-build-xdi-sync-endpoint --auth=$TRANSCEND_API_KEY --xdiLocation=https://cdn.your-site.com/xdi.js --domainBlockList=ignored.com,localhost
```

Override XDI allowed commands

```sh
yarn tr-build-xdi-sync-endpoint --auth=$TRANSCEND_API_KEY --xdiLocation=https://cdn.your-site.com/xdi.js --xdiAllowedCommands="ExtractIdentifiers:Simple"
```
