### PR TITLE
Fixes bug applying category without name

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/cli",
   "description": "Small package containing useful typescript utilities.",
-  "version": "4.68.0",
+  "version": "4.69.0",
   "homepage": "https://github.com/transcend-io/cli",
   "repository": {
     "type": "git",

--- a/src/graphql/syncDataSilos.ts
+++ b/src/graphql/syncDataSilos.ts
@@ -733,7 +733,7 @@ export async function syncDataSilo(
                     ? undefined
                     : categories.map((category) => ({
                         ...category,
-                        name: category.name || '',
+                        name: category.name || 'Other',
                       })),
                   purposes,
                   attributes,


### PR DESCRIPTION
Categories without a name should default to `Other`, which is the name provided to those datapoints under the hood.