### PR TITLE
Env var for transcend url

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ tr-pull --auth=$TRANSCEND_API_KEY
 
 Note:
 
-_The cli-commands default to using the EU Transcend backend. To use these commands with the US backend, you will need to use the flag --transcendUrl=https://api.us.transcend.io._
+_The cli-commands default to using the EU Transcend backend. To use these commands with the US backend, you will need to use the flag --transcendUrl=https://api.us.transcend.io. You can also set the environment variable `TRANSCEND_API_URL=https://api.us.transcend.io`_
 
 ## transcend.yml
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/cli",
   "description": "Small package containing useful typescript utilities.",
-  "version": "4.71.0",
+  "version": "4.72.0",
   "homepage": "https://github.com/transcend-io/cli",
   "repository": {
     "type": "git",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,4 +2,9 @@ export const ADMIN_DASH = 'https://app.transcend.io';
 
 export const ADMIN_DASH_INTEGRATIONS = `${ADMIN_DASH}/infrastructure/integrations`;
 
-export const DEFAULT_TRANSCEND_API = 'https://api.transcend.io';
+/**
+ * Override default transcend API url using
+ * TRANSCEND_API_URL=https://api.us.transcend.io tr-pull ...
+ */
+export const DEFAULT_TRANSCEND_API =
+  process.env.TRANSCEND_API_URL || 'https://api.transcend.io';


### PR DESCRIPTION


Allow for setting API url:

`TRANSCEND_API_URL=https://api.us.transcend.io` 