### PR TITLE
Add tr-upload-cookies-from-csv

### DIFF
--- a/README.md
+++ b/README.md
@@ -1607,7 +1607,7 @@ The API key must have the following scopes:
 | file          | Path to the CSV file to upload                                                                          | string - file-path   | ./cookies.csv            | false    |
 | transcendUrl  | URL of the Transcend backend. Use https://api.us.transcend.io for US hosting.                           | string - URL         | https://api.transcend.io | false    |
 
-Note: You `trackerStatus` can be specified on a per data flow basis by adding a column named "Status" to the CSV. The values should be of type `ConsentTrackerStatus` - which is `LIVE` or `NEEDS_REVIEW`.
+Note: You `trackerStatus` can be specified on a per cookie basis by adding a column named "Status" to the CSV. The values should be of type `ConsentTrackerStatus` - which is `LIVE` or `NEEDS_REVIEW`.
 
 #### Usage
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 
 ## Table of Contents
 
+- [Table of Contents](#table-of-contents)
 - [Overview](#overview)
 - [Installation](#installation)
 - [transcend.yml](#transcendyml)
@@ -81,14 +82,18 @@
     - [Authentication](#authentication-17)
     - [Arguments](#arguments-17)
     - [Usage](#usage-18)
-  - [tr-generate-api-keys](#tr-generate-api-keys)
+  - [tr-upload-cookies-from-csv](#tr-upload-cookies-from-csv)
     - [Authentication](#authentication-18)
     - [Arguments](#arguments-18)
     - [Usage](#usage-19)
-  - [tr-build-xdi-sync-endpoint](#tr-build-xdi-sync-endpoint)
+  - [tr-generate-api-keys](#tr-generate-api-keys)
     - [Authentication](#authentication-19)
     - [Arguments](#arguments-19)
     - [Usage](#usage-20)
+  - [tr-build-xdi-sync-endpoint](#tr-build-xdi-sync-endpoint)
+    - [Authentication](#authentication-20)
+    - [Arguments](#arguments-20)
+    - [Usage](#usage-21)
 - [Proxy usage](#proxy-usage)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -125,6 +130,7 @@ yarn tr-retry-request-data-silos --auth=$TRANSCEND_API_KEY
 yarn tr-update-consent-manager --auth=$TRANSCEND_API_KEY
 yarn tr-pull-consent-metrics --auth=$TRANSCEND_API_KEY
 yarn tr-upload-data-flows-from-csv --auth=$TRANSCEND_API_KEY
+yarn tr-upload-cookies-from-csv --auth=$TRANSCEND_API_KEY
 yarn tr-generate-api-keys --auth=$TRANSCEND_API_KEY
 yarn tr-build-xdi-sync-endpoint --auth=$TRANSCEND_API_KEY
 ```
@@ -1572,6 +1578,61 @@ Specifying the backend URL, needed for US hosted backend infrastructure.
 
 ```sh
 yarn tr-upload-data-flows-from-csv --auth=$TRANSCEND_API_KEY --transcendUrl=https://api.us.transcend.io
+```
+
+### tr-upload-cookies-from-csv
+
+This command allows for uploading cookies from CSV
+
+Step 1) Download the CSV of cookies that you want to edit from the Admin Dashboard under [Consent Manager -> Cookies](https://app.transcend.io/consent-manager/cookies). You can download cookies from both the "Triage" and "Approved" tabs.
+
+Step 2) You can edit the contents of the CSV file as needed. You may adjust the "Purpose" column, adjust the "Notes" column, add "Owners" and "Teams" or even add custom columns with additional metadata.
+
+Step 3) Upload the modified CSV file back into the dashboard with the command `yarn tr-upload-cookies-from-csv --auth=$TRANSCEND_API_KEY --file=./approved-flows.csv --trackerStatus=LIVE`
+
+#### Authentication
+
+In order to use this cli, you will first need to generate an API key on the Transcend Admin Dashboard (https://app.transcend.io/infrastructure/api-keys).
+
+The API key must have the following scopes:
+
+- "Manage Data Flows"
+
+#### Arguments
+
+| Argument      | Description                                                                                             | Type                 | Default                  | Required |
+| ------------- | ------------------------------------------------------------------------------------------------------- | -------------------- | ------------------------ | -------- |
+| auth          | The Transcend API key with the scopes necessary for the command.                                        | string               | N/A                      | true     |
+| trackerStatus | Whether or not to upload the cookies into the "Approved" tab (LIVE) or the "Triage" tab (NEEDS_REVIEW). | ConsentTrackerStatus | N/A                      | true     |
+| file          | Path to the CSV file to upload                                                                          | string - file-path   | ./cookies.csv            | false    |
+| transcendUrl  | URL of the Transcend backend. Use https://api.us.transcend.io for US hosting.                           | string - URL         | https://api.transcend.io | false    |
+
+Note: You `trackerStatus` can be specified on a per data flow basis by adding a column named "Status" to the CSV. The values should be of type `ConsentTrackerStatus` - which is `LIVE` or `NEEDS_REVIEW`.
+
+#### Usage
+
+Upload the file of cookies in `./data-flows.csv` into the ["Approved" tab](https://app.transcend.io/consent-manager/cookies/approved).
+
+```sh
+yarn tr-upload-cookies-from-csv --auth=$TRANSCEND_API_KEY --trackerStatus=LIVE
+```
+
+Upload the file of cookies in `./data-flows.csv` into the ["Triage" tab](https://app.transcend.io/consent-manager/cookies).
+
+```sh
+yarn tr-upload-cookies-from-csv --auth=$TRANSCEND_API_KEY --trackerStatus=NEEDS_REVIEW
+```
+
+Specifying the CSV file to read from:
+
+```sh
+yarn tr-upload-cookies-from-csv --auth=$TRANSCEND_API_KEY --trackerStatus=LIVE --file=./custom/my-cookies.csv
+```
+
+Specifying the backend URL, needed for US hosted backend infrastructure.
+
+```sh
+yarn tr-upload-cookies-from-csv --auth=$TRANSCEND_API_KEY --transcendUrl=https://api.us.transcend.io
 ```
 
 ### tr-generate-api-keys

--- a/README.md
+++ b/README.md
@@ -1611,7 +1611,7 @@ Note: You `trackerStatus` can be specified on a per cookie basis by adding a col
 
 #### Usage
 
-Upload the file of cookies in `./data-flows.csv` into the ["Approved" tab](https://app.transcend.io/consent-manager/cookies/approved).
+Upload the file of cookies in `./cookies.csv` into the ["Approved" tab](https://app.transcend.io/consent-manager/cookies/approved).
 
 ```sh
 yarn tr-upload-cookies-from-csv --auth=$TRANSCEND_API_KEY --trackerStatus=LIVE

--- a/README.md
+++ b/README.md
@@ -1596,7 +1596,7 @@ In order to use this cli, you will first need to generate an API key on the Tran
 
 The API key must have the following scopes:
 
-- "Manage Data Flows"
+- "Manage Cookies"
 
 #### Arguments
 

--- a/README.md
+++ b/README.md
@@ -1617,7 +1617,7 @@ Upload the file of cookies in `./data-flows.csv` into the ["Approved" tab](https
 yarn tr-upload-cookies-from-csv --auth=$TRANSCEND_API_KEY --trackerStatus=LIVE
 ```
 
-Upload the file of cookies in `./data-flows.csv` into the ["Triage" tab](https://app.transcend.io/consent-manager/cookies).
+Upload the file of cookies in `./cookies.csv` into the ["Triage" tab](https://app.transcend.io/consent-manager/cookies).
 
 ```sh
 yarn tr-upload-cookies-from-csv --auth=$TRANSCEND_API_KEY --trackerStatus=NEEDS_REVIEW

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
     "tr-retry-request-data-silos": "./build/cli-retry-request-data-silos.js",
     "tr-skip-request-data-silos": "./build/cli-skip-request-data-silos.js",
     "tr-update-consent-manager": "./build/cli-update-consent-manager-to-latest.js",
-    "tr-upload-data-flows-from-csv": "./build/cli-upload-data-flows-from-csv.js",
-    "tr-upload-cookies-from-csv": "./build/cli-upload-cookies-from-csv.js"
+    "tr-upload-cookies-from-csv": "./build/cli-upload-cookies-from-csv.js",
+    "tr-upload-data-flows-from-csv": "./build/cli-upload-data-flows-from-csv.js"
   },
   "files": [
     "build/**/*",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "yargs-parser": "^21.1.1"
   },
   "devDependencies": {
-    "@transcend-io/cli": "^4.72.0",
     "@types/bluebird": "^3.5.38",
     "@types/chai": "^4.3.4",
     "@types/cli-progress": "^3.11.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "tr-retry-request-data-silos": "./build/cli-retry-request-data-silos.js",
     "tr-skip-request-data-silos": "./build/cli-skip-request-data-silos.js",
     "tr-update-consent-manager": "./build/cli-update-consent-manager-to-latest.js",
-    "tr-upload-data-flows-from-csv": "./build/cli-upload-data-flows-from-csv.js"
+    "tr-upload-data-flows-from-csv": "./build/cli-upload-data-flows-from-csv.js",
+    "tr-upload-cookies-from-csv": "./build/cli-upload-cookies-from-csv.js"
   },
   "files": [
     "build/**/*",
@@ -73,6 +74,7 @@
     "yargs-parser": "^21.1.1"
   },
   "devDependencies": {
+    "@transcend-io/cli": "^4.72.0",
     "@types/bluebird": "^3.5.38",
     "@types/chai": "^4.3.4",
     "@types/cli-progress": "^3.11.0",

--- a/src/cli-upload-cookies-from-csv.ts
+++ b/src/cli-upload-cookies-from-csv.ts
@@ -24,10 +24,6 @@ import { DEFAULT_TRANSCEND_API } from './constants';
  *   --file=/Users/michaelfarrell/Desktop/test.csv \
  *   --trackerStatus=LIVE
  */
-
-/**
- *
- */
 async function main(): Promise<void> {
   // Parse command line arguments
   const {

--- a/src/cli-upload-cookies-from-csv.ts
+++ b/src/cli-upload-cookies-from-csv.ts
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+
+import yargs from 'yargs-parser';
+import colors from 'colors';
+
+import { logger } from './logger';
+import { uploadCookiesFromCsv } from './consent-manager';
+import { ConsentTrackerStatus } from '@transcend-io/privacy-types';
+import { DEFAULT_TRANSCEND_API } from './constants';
+
+/**
+ * Upload a CSV of cookies
+ *
+ * Requires an API key with follow scopes: https://app.transcend.io/infrastructure/api-keys
+ *    - "Manage Consent Manager"
+ *
+ * Dev Usage:
+ * yarn ts-node ./src/cli-upload-cookies-from-csv.ts --auth=$TRANSCEND_API_KEY \
+ *   --file=/Users/michaelfarrell/Desktop/test.csv \
+ *   --trackerStatus=LIVE
+ *
+ * Standard usage:
+ * yarn tr-upload-cookies-from-csv --auth=$TRANSCEND_API_KEY \
+ *   --file=/Users/michaelfarrell/Desktop/test.csv \
+ *   --trackerStatus=LIVE
+ */
+
+/**
+ *
+ */
+async function main(): Promise<void> {
+  // Parse command line arguments
+  const {
+    auth,
+    trackerStatus,
+    file = 'cookies.csv',
+    transcendUrl = DEFAULT_TRANSCEND_API,
+  } = yargs(process.argv.slice(2)) as { [k in string]: string };
+
+  // Ensure auth is passed
+  if (!auth) {
+    logger.error(
+      colors.red(
+        'A Transcend API key must be provided. You can specify using --auth=$TRANSCEND_API_KEY',
+      ),
+    );
+    process.exit(1);
+  }
+
+  // Ensure trackerStatus is passed
+  const VALID_TRACKER_OPTIONS = Object.values(ConsentTrackerStatus);
+  if (!trackerStatus) {
+    logger.error(
+      colors.red(
+        'The trackerStatus must be provided. You can specify using --trackerStatus=LIVE. ' +
+          `Valid options include: ${VALID_TRACKER_OPTIONS.join(',')}`,
+      ),
+    );
+    process.exit(1);
+  }
+
+  const consentTrackerStatus = trackerStatus as ConsentTrackerStatus;
+  if (!VALID_TRACKER_OPTIONS.includes(consentTrackerStatus)) {
+    logger.error(
+      colors.red(
+        `The trackerStatus option was invalid, got: "${trackerStatus}". You can specify using --trackerStatus=LIVE. ` +
+          `Valid options include: ${VALID_TRACKER_OPTIONS.join(',')}`,
+      ),
+    );
+    process.exit(1);
+  }
+
+  // Upload cookies
+  await uploadCookiesFromCsv({
+    auth,
+    trackerStatus: consentTrackerStatus,
+    file,
+    transcendUrl,
+  });
+}
+
+main();

--- a/src/codecs.ts
+++ b/src/codecs.ts
@@ -843,5 +843,32 @@ export const DataFlowCsvInput = t.intersection([
   t.record(t.string, t.string),
 ]);
 
+export const CookieCsvInput = t.intersection([
+  t.type({
+    /** The value of the cookie */
+    Name: t.string,
+    /** The CSV of purposes mapped to that cookie */
+    Purpose: t.string,
+  }),
+  t.partial({
+    /** The service that the cookie relates to */
+    Service: t.string,
+    /** Notes and descriptions for the cookie */
+    Notes: t.string,
+    /** Set of cookie owners */
+    Owners: t.string,
+    /** Set of cookie team owners */
+    Teams: t.string,
+    /** LIVE vs NEEDS_REVIEW aka Approved vs Triage  */
+    Status: valuesOf(ConsentTrackerStatus),
+  }),
+  // Custom attributes
+  t.record(t.string, t.string),
+]);
+
 /** Type override */
 export type DataFlowCsvInput = t.TypeOf<typeof DataFlowCsvInput>;
+/**
+ *
+ */
+export type CookieCsvInput = t.TypeOf<typeof CookieCsvInput>;

--- a/src/codecs.ts
+++ b/src/codecs.ts
@@ -843,6 +843,9 @@ export const DataFlowCsvInput = t.intersection([
   t.record(t.string, t.string),
 ]);
 
+/** Type override */
+export type DataFlowCsvInput = t.TypeOf<typeof DataFlowCsvInput>;
+
 export const CookieCsvInput = t.intersection([
   t.type({
     /** The value of the cookie */
@@ -867,8 +870,4 @@ export const CookieCsvInput = t.intersection([
 ]);
 
 /** Type override */
-export type DataFlowCsvInput = t.TypeOf<typeof DataFlowCsvInput>;
-/**
- *
- */
 export type CookieCsvInput = t.TypeOf<typeof CookieCsvInput>;

--- a/src/consent-manager/index.ts
+++ b/src/consent-manager/index.ts
@@ -1,4 +1,5 @@
 export * from './updateConsentManagerVersionToLatest';
 export * from './uploadDataFlowsFromCsv';
+export * from './uploadCookiesFromCsv';
 export * from './pullConsentManagerMetrics';
 export * from './buildXdiSyncEndpoint';

--- a/src/consent-manager/uploadCookiesFromCsv.ts
+++ b/src/consent-manager/uploadCookiesFromCsv.ts
@@ -1,0 +1,97 @@
+import colors from 'colors';
+import { logger } from '../logger';
+import { ConsentTrackerStatus } from '@transcend-io/privacy-types';
+import { buildTranscendGraphQLClient, syncCookies } from '../graphql';
+import { readCsv } from '../requests/readCsv';
+import { CookieInput, CookieCsvInput } from '../codecs';
+import { splitCsvToList } from '../requests';
+import { DEFAULT_TRANSCEND_API } from '../constants';
+
+const OMIT_COLUMNS = [
+  'ID',
+  'Activity',
+  'Encounters',
+  'Last Seen At',
+  'Has Native Do Not Sell/Share Support',
+  'IAB USP API Support',
+  'Service Description',
+  'Website URL',
+  'Categories of Recipients',
+];
+
+/**
+ * Upload a set of cookies from CSV
+ *
+ * @param options - Options
+ */
+export async function uploadCookiesFromCsv({
+  auth,
+  trackerStatus,
+  file,
+  transcendUrl = DEFAULT_TRANSCEND_API,
+}: {
+  /** CSV file path */
+  file: string;
+  /** Transcend API key authentication */
+  auth: string;
+  /** Sombra API key authentication */
+  trackerStatus: ConsentTrackerStatus;
+  /** API URL for Transcend backend */
+  transcendUrl?: string;
+}): Promise<void> {
+  // Build a GraphQL client
+  const client = buildTranscendGraphQLClient(transcendUrl, auth);
+
+  // Read from CSV the set of cookie inputs
+  logger.info(colors.magenta(`Reading "${file}" from disk`));
+  const cookieInputs = readCsv(file, CookieCsvInput);
+
+  // Convert these  inputs into a format that the other function can use
+  const validatedCookieInputs = cookieInputs.map(
+    ({
+      Notes,
+      // TODO: https://transcend.height.app/T-26391 - export in CSV
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      Service,
+      Purpose,
+      Status,
+      Owners,
+      Teams,
+      'Connections Made To': name,
+      ...rest
+    }): CookieInput => ({
+      name,
+      description: Notes,
+      trackingPurposes: splitCsvToList(Purpose),
+      // TODO: https://transcend.height.app/T-26391
+      // service: Service,
+      // Apply the trackerStatus to all values in the CSV -> allows for customer to define tracker status
+      // on a row by row basis if needed
+      status: Status || trackerStatus,
+      owners: Owners ? splitCsvToList(Owners) : undefined,
+      teams: Teams ? splitCsvToList(Teams) : undefined,
+      // all remaining options are attribute
+      attributes: Object.entries(rest)
+        // filter out native columns that are exported from the admin dashboard
+        // but not custom attributes
+        .filter(([key]) => !OMIT_COLUMNS.includes(key))
+        .map(([key, value]) => ({
+          key,
+          values: splitCsvToList(value),
+        })),
+    }),
+  );
+
+  // Upload the cookies into Transcend dashboard
+  const syncedCookies = await syncCookies(client, validatedCookieInputs);
+
+  // Log errors
+  if (!syncedCookies) {
+    logger.error(
+      colors.red(
+        'Encountered error(s) syncing cookies from CSV, see logs above for more info. ',
+      ),
+    );
+    process.exit(1);
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -473,6 +473,7 @@ __metadata:
     tr-retry-request-data-silos: ./build/cli-retry-request-data-silos.js
     tr-skip-request-data-silos: ./build/cli-skip-request-data-silos.js
     tr-update-consent-manager: ./build/cli-update-consent-manager-to-latest.js
+    tr-upload-cookies-from-csv: ./build/cli-upload-cookies-from-csv.js
     tr-upload-data-flows-from-csv: ./build/cli-upload-data-flows-from-csv.js
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Related Issues

closes https://transcend.height.app/T-27654 

This command allows for uploading cookies from CSV

Step 1) Download the CSV of cookies that you want to edit from the Admin Dashboard under [Consent Manager -> Cookies](https://app.transcend.io/consent-manager/cookies). You can download cookies from both the "Triage" and "Approved" tabs.

Step 2) You can edit the contents of the CSV file as needed. You may adjust the "Purpose" column, adjust the "Notes" column, add "Owners" and "Teams" or even add custom columns with additional metadata.

Step 3) Upload the modified CSV file back into the dashboard with the command `yarn tr-upload-cookies-from-csv --auth=$TRANSCEND_API_KEY --file=./approved-flows.csv --trackerStatus=LIVE`

#### Authentication

In order to use this cli, you will first need to generate an API key on the Transcend Admin Dashboard (https://app.transcend.io/infrastructure/api-keys).

The API key must have the following scopes:

- "Manage Cookies"

#### Arguments

| Argument      | Description                                                                                             | Type                 | Default                  | Required |
| ------------- | ------------------------------------------------------------------------------------------------------- | -------------------- | ------------------------ | -------- |
| auth          | The Transcend API key with the scopes necessary for the command.                                        | string               | N/A                      | true     |
| trackerStatus | Whether or not to upload the cookies into the "Approved" tab (LIVE) or the "Triage" tab (NEEDS_REVIEW). | ConsentTrackerStatus | N/A                      | true     |
| file          | Path to the CSV file to upload                                                                          | string - file-path   | ./cookies.csv            | false    |
| transcendUrl  | URL of the Transcend backend. Use https://api.us.transcend.io for US hosting.                           | string - URL         | https://api.transcend.io | false    |

Note: You `trackerStatus` can be specified on a per cookie basis by adding a column named "Status" to the CSV. The values should be of type `ConsentTrackerStatus` - which is `LIVE` or `NEEDS_REVIEW`.

#### Usage

Upload the file of cookies in `./cookies.csv` into the ["Approved" tab](https://app.transcend.io/consent-manager/cookies/approved).

```sh
yarn tr-upload-cookies-from-csv --auth=$TRANSCEND_API_KEY --trackerStatus=LIVE
```

Upload the file of cookies in `./cookies.csv` into the ["Triage" tab](https://app.transcend.io/consent-manager/cookies).

```sh
yarn tr-upload-cookies-from-csv --auth=$TRANSCEND_API_KEY --trackerStatus=NEEDS_REVIEW
```

Specifying the CSV file to read from:

```sh
yarn tr-upload-cookies-from-csv --auth=$TRANSCEND_API_KEY --trackerStatus=LIVE --file=./custom/my-cookies.csv
```

Specifying the backend URL, needed for US hosted backend infrastructure.

```sh
yarn tr-upload-cookies-from-csv --auth=$TRANSCEND_API_KEY --transcendUrl=https://api.us.transcend.io
```
