### PR TITLE
New cli command tr-consent-managers-to-business-entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,22 +73,26 @@
     - [Authentication](#authentication-15)
     - [Arguments](#arguments-15)
     - [Usage](#usage-16)
-  - [tr-pull-consent-metrics](#tr-pull-consent-metrics)
+  - [tr-consent-managers-to-business-entities](#tr-consent-managers-to-business-entities)
     - [Authentication](#authentication-16)
     - [Arguments](#arguments-16)
     - [Usage](#usage-17)
-  - [tr-upload-data-flows-from-csv](#tr-upload-data-flows-from-csv)
+  - [tr-pull-consent-metrics](#tr-pull-consent-metrics)
     - [Authentication](#authentication-17)
     - [Arguments](#arguments-17)
     - [Usage](#usage-18)
-  - [tr-generate-api-keys](#tr-generate-api-keys)
+  - [tr-upload-data-flows-from-csv](#tr-upload-data-flows-from-csv)
     - [Authentication](#authentication-18)
     - [Arguments](#arguments-18)
     - [Usage](#usage-19)
-  - [tr-build-xdi-sync-endpoint](#tr-build-xdi-sync-endpoint)
+  - [tr-generate-api-keys](#tr-generate-api-keys)
     - [Authentication](#authentication-19)
     - [Arguments](#arguments-19)
     - [Usage](#usage-20)
+  - [tr-build-xdi-sync-endpoint](#tr-build-xdi-sync-endpoint)
+    - [Authentication](#authentication-20)
+    - [Arguments](#arguments-20)
+    - [Usage](#usage-21)
 - [Proxy usage](#proxy-usage)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -123,6 +127,7 @@ yarn tr-mark-request-data-silos-completed --auth=$TRANSCEND_API_KEY
 yarn tr-skip-request-data-silos --auth=$TRANSCEND_API_KEY
 yarn tr-retry-request-data-silos --auth=$TRANSCEND_API_KEY
 yarn tr-update-consent-manager --auth=$TRANSCEND_API_KEY
+yarn tr-consent-managers-to-business-entities --auth=$TRANSCEND_API_KEY
 yarn tr-pull-consent-metrics --auth=$TRANSCEND_API_KEY
 yarn tr-upload-data-flows-from-csv --auth=$TRANSCEND_API_KEY
 yarn tr-generate-api-keys --auth=$TRANSCEND_API_KEY
@@ -152,6 +157,7 @@ tr-skip-request-data-silos --auth=$TRANSCEND_API_KEY
 tr-retry-request-data-silos --auth=$TRANSCEND_API_KEY
 tr-update-consent-manager --auth=$TRANSCEND_API_KEY
 tr-pull-consent-metrics --auth=$TRANSCEND_API_KEY
+tr-consent-managers-to-business-entities --auth=$TRANSCEND_API_KEY
 tr-upload-data-flows-from-csv --auth=$TRANSCEND_API_KEY
 tr-generate-api-keys --auth=$TRANSCEND_API_KEY
 tr-build-xdi-sync-endpoint --auth=$TRANSCEND_API_KEY
@@ -1455,6 +1461,35 @@ yarn tr-update-consent-manager --auth=$TRANSCEND_API_KEY --bundleTypes=PRODUCTIO
 
 tr-generate-api-keys  --email=test@transcend.io --password=$TRANSCEND_PASSWORD --scopes="Manage Consent Manager" --apiKeyTitle="CLI Usage Cross Instance Sync" --file=./transcend-api-keys.json
 yarn tr-update-consent-manager  --auth=./transcend-api-keys.json --deploy=true
+```
+
+### tr-consent-managers-to-business-entities
+
+This command allows for converting a folder or Consent Manager `transcend.yml` files into a single `transcend.yml` file where each consent manager configuration is a Business Entity in the data inventory.
+
+#### Authentication
+
+No authentication is required to run this command. It reads and writes files from local disk.
+
+#### Arguments
+
+| Argument                | Description                                                            | Type                 | Default                          | Required |
+| ----------------------- | ---------------------------------------------------------------------- | -------------------- | -------------------------------- | -------- |
+| consentManagerYmlFolder | Path to the folder of Consent Manager `transcend.yml` files to combine | string - folder-path | N/A                              | true     |
+| output                  | Path to the output `transcend.yml` with business entity configuration  | string - file-path   | ./combined-business-entities.yml | false    |
+
+#### Usage
+
+Combine files in folder `./working/consent-managers/` to file `./combined-business-entities.yml`
+
+```sh
+yarn tr-consent-managers-to-business-entities --consentManagerYmlFolder=./working/consent-managers/
+```
+
+Specify custom output file
+
+```sh
+yarn tr-consent-managers-to-business-entities --consentManagerYmlFolder=./working/consent-managers/ --output=./custom.yml
 ```
 
 ### tr-pull-consent-metrics

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/cli",
   "description": "Small package containing useful typescript utilities.",
-  "version": "4.72.0",
+  "version": "4.73.0",
   "homepage": "https://github.com/transcend-io/cli",
   "repository": {
     "type": "git",
@@ -12,6 +12,7 @@
   "main": "build/index",
   "bin": {
     "tr-build-xdi-sync-endpoint": "./build/cli-build-xdi-sync-endpoint.js",
+    "tr-consent-managers-to-business-entities": "cli-consent-managers-to-business-entities.ts",
     "tr-cron-mark-identifiers-completed": "./build/cli-cron-mark-identifiers-completed.js",
     "tr-cron-pull-identifiers": "./build/cli-cron-pull-identifiers.js",
     "tr-discover-silos": "./build/cli-discover-silos.js",

--- a/src/cli-consent-managers-to-business-entities.ts
+++ b/src/cli-consent-managers-to-business-entities.ts
@@ -1,0 +1,75 @@
+#!/usr/bin/env/node
+import { listFiles } from './api-keys';
+import { consentManagersToBusinessEntities } from './consent-manager';
+import { readTranscendYaml, writeTranscendYaml } from './readTranscendYaml';
+import { join } from 'path';
+import yargs from 'yargs-parser';
+import colors from 'colors';
+import { logger } from './logger';
+import { existsSync, lstatSync } from 'fs';
+
+/**
+ * Combines folder of consent manager `transcend.yml` files into a single `transcend.yml` file
+ * where each consent manager configuration is created as a business entity.
+ *
+ * yarn ts-node ./src/cli-consent-managers-to-business-entities.ts \
+ *   --consentManagerYmlFolder=./working/consent-managers/ \
+ *   --output=./combined-business-entities.yml
+ *
+ * Standard usage:
+ * yarn tr-consent-managers-to-business-entities \
+ *   --consentManagerYmlFolder=./working/consent-managers/ \
+ *   --output=./combined-business-entities.yml
+ */
+function main(): void {
+  // Parse command line arguments
+  const {
+    consentManagerYmlFolder,
+    output = './combined-business-entities.yml',
+  } = yargs(process.argv.slice(2)) as { [k in string]: string };
+
+  // Ensure folder is passed to consentManagerYmlFolder
+  if (!consentManagerYmlFolder) {
+    logger.error(
+      colors.red(
+        'Missing required arg: --consentManagerYmlFolder=./working/consent-managers/',
+      ),
+    );
+    process.exit(1);
+  }
+
+  // Ensure file is passed
+  if (
+    !existsSync(consentManagerYmlFolder) ||
+    !lstatSync(consentManagerYmlFolder).isDirectory()
+  ) {
+    logger.error(
+      colors.red(`Folder does not exist: "${consentManagerYmlFolder}"`),
+    );
+    process.exit(1);
+  }
+
+  // Read in each consent manager configuration
+  const inputs = listFiles(consentManagerYmlFolder).map((directory) => {
+    const { 'consent-manager': consentManager } = readTranscendYaml(
+      join(consentManagerYmlFolder, directory),
+    );
+    return { name: directory, input: consentManager };
+  });
+
+  // Convert to business entities
+  const businessEntities = consentManagersToBusinessEntities(inputs);
+
+  // write to disk
+  writeTranscendYaml(output, {
+    'business-entities': businessEntities,
+  });
+
+  logger.info(
+    colors.green(
+      `Successfully wrote ${businessEntities.length} business entities to file "${output}"`,
+    ),
+  );
+}
+
+main();

--- a/src/consent-manager/buildXdiSyncEndpoint.ts
+++ b/src/consent-manager/buildXdiSyncEndpoint.ts
@@ -6,6 +6,7 @@ import { map } from 'bluebird';
 import { StoredApiKey } from '../codecs';
 import { DEFAULT_TRANSCEND_API } from '../constants';
 import { logger } from '../logger';
+import { domainToHost } from './domainToHost';
 
 /**
  * Sync group configuration mapping
@@ -25,15 +26,6 @@ export type XdiSyncGroups = { [k in string]: string[] };
 export const IP_ADDRESS_REGEX =
   // eslint-disable-next-line max-len
   /^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;
-
-/**
- * Convert a domain to host
- *
- * @param domain - e.g. test.acme.com
- * @returns Host acme.com
- */
-const domainToHost = (domain: string): string =>
-  new URL(`https://${domain}`).hostname.split('.').slice(-2).join('.');
 
 /**
  * Build the sync endpoint definition for a set of Transcend accounts

--- a/src/consent-manager/consentManagersToBusinessEntities.ts
+++ b/src/consent-manager/consentManagersToBusinessEntities.ts
@@ -1,0 +1,76 @@
+import { BusinessEntityInput, ConsentManagerInput } from '../codecs';
+import { logger } from '../logger';
+
+/**
+ * Combine multiple consent manager configurations into a list of business entity configurations
+ *
+ * @param inputs - Consent manager configurations to combine
+ * @returns Business entity configuration input
+ */
+export function consentManagersToBusinessEntities(
+  inputs: {
+    /** Name of business entity */
+    name: string;
+    /** Consent manager input */
+    input?: ConsentManagerInput;
+  }[],
+): BusinessEntityInput[] {
+  // Construct the business entities YAML definition
+  const businessEntities = inputs.map(
+    ({ name, input }): BusinessEntityInput => ({
+      // Title of Transcend Instance
+      title: name.replace('.yml', ''),
+      attributes: [
+        // Sync domain list
+        ...(input?.domains
+          ? [
+              {
+                key: 'Transcend Domain List',
+                values: [...new Set(input.domains)],
+              },
+            ]
+          : []),
+        // Sync bundle URLs
+        ...(input?.bundleUrls
+          ? [
+              {
+                key: 'Airgap Production URL',
+                values: [input.bundleUrls.PRODUCTION],
+              },
+              {
+                key: 'Airgap Test URL',
+                values: [input.bundleUrls.TEST],
+              },
+              {
+                key: 'Airgap XDI URL',
+                values: [
+                  input.bundleUrls.PRODUCTION.replace('airgap.js', 'xdi.js'),
+                ],
+              },
+            ]
+          : []),
+        // Sync partition keys
+        ...(input?.partition
+          ? [
+              {
+                key: 'Consent Partition Key',
+                values: [input.partition],
+              },
+            ]
+          : []),
+      ],
+    }),
+  );
+
+  // Log out info on airgap scripts to host
+  logger.info('\n\n~~~~~~~~~~~\nAirgap scripts to host:');
+  businessEntities.forEach(({ attributes, title }, ind) => {
+    attributes
+      ?.find((attr) => attr.key === 'Airgap Production URL')
+      ?.values?.forEach((url) => {
+        logger.info(`${ind}) ${title} - ${url}`);
+      });
+  });
+
+  return businessEntities;
+}

--- a/src/consent-manager/domainToHost.ts
+++ b/src/consent-manager/domainToHost.ts
@@ -1,0 +1,8 @@
+/**
+ * Convert a domain to host
+ *
+ * @param domain - e.g. test.acme.com
+ * @returns Host acme.com
+ */
+export const domainToHost = (domain: string): string =>
+  new URL(`https://${domain}`).hostname.split('.').slice(-2).join('.');

--- a/src/consent-manager/index.ts
+++ b/src/consent-manager/index.ts
@@ -2,3 +2,5 @@ export * from './updateConsentManagerVersionToLatest';
 export * from './uploadDataFlowsFromCsv';
 export * from './pullConsentManagerMetrics';
 export * from './buildXdiSyncEndpoint';
+export * from './consentManagersToBusinessEntities';
+export * from './domainToHost';

--- a/yarn.lock
+++ b/yarn.lock
@@ -455,6 +455,7 @@ __metadata:
     yargs-parser: ^21.1.1
   bin:
     tr-build-xdi-sync-endpoint: ./build/cli-build-xdi-sync-endpoint.js
+    tr-consent-managers-to-business-entities: cli-consent-managers-to-business-entities.ts
     tr-cron-mark-identifiers-completed: ./build/cli-cron-mark-identifiers-completed.js
     tr-cron-pull-identifiers: ./build/cli-cron-pull-identifiers.js
     tr-discover-silos: ./build/cli-discover-silos.js


### PR DESCRIPTION
### tr-consent-managers-to-business-entities

This command allows for converting a folder or Consent Manager `transcend.yml` files into a single `transcend.yml` file where each consent manager configuration is a Business Entity in the data inventory.

#### Authentication

No authentication is required to run this command. It reads and writes files from local disk.

#### Arguments

| Argument                | Description                                                            | Type                 | Default                          | Required |
| ----------------------- | ---------------------------------------------------------------------- | -------------------- | -------------------------------- | -------- |
| consentManagerYmlFolder | Path to the folder of Consent Manager `transcend.yml` files to combine | string - folder-path | N/A                              | true     |
| output                  | Path to the output `transcend.yml` with business entity configuration  | string - file-path   | ./combined-business-entities.yml | false    |

#### Usage

Combine files in folder `./working/consent-managers/` to file `./combined-business-entities.yml`

```sh
yarn tr-consent-managers-to-business-entities --consentManagerYmlFolder=./working/consent-managers/
```

Specify custom output file

```sh
yarn tr-consent-managers-to-business-entities --consentManagerYmlFolder=./working/consent-managers/ --output=./custom.yml
```