### PR TITLE
Cli commands to convert data flow configurations to data silo configurations

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -69,7 +69,8 @@
     "Upserting",
     "uspapi",
     "yaml",
-    "yarnpkg"
+    "yarnpkg",
+    "Ymls"
   ],
   "javascript.preferences.importModuleSpecifier": "relative",
   "typescript.preferences.importModuleSpecifier": "relative"

--- a/README.md
+++ b/README.md
@@ -77,26 +77,34 @@
     - [Authentication](#authentication-16)
     - [Arguments](#arguments-16)
     - [Usage](#usage-17)
-  - [tr-pull-consent-metrics](#tr-pull-consent-metrics)
+  - [tr-derive-data-silos-from-data-flows](#tr-derive-data-silos-from-data-flows)
     - [Authentication](#authentication-17)
     - [Arguments](#arguments-17)
     - [Usage](#usage-18)
-  - [tr-upload-data-flows-from-csv](#tr-upload-data-flows-from-csv)
+  - [tr-derive-data-silos-from-data-flows-cross-instance](#tr-derive-data-silos-from-data-flows-cross-instance)
     - [Authentication](#authentication-18)
     - [Arguments](#arguments-18)
     - [Usage](#usage-19)
-  - [tr-upload-cookies-from-csv](#tr-upload-cookies-from-csv)
+  - [tr-pull-consent-metrics](#tr-pull-consent-metrics)
     - [Authentication](#authentication-19)
     - [Arguments](#arguments-19)
     - [Usage](#usage-20)
-  - [tr-generate-api-keys](#tr-generate-api-keys)
+  - [tr-upload-data-flows-from-csv](#tr-upload-data-flows-from-csv)
     - [Authentication](#authentication-20)
     - [Arguments](#arguments-20)
     - [Usage](#usage-21)
-  - [tr-build-xdi-sync-endpoint](#tr-build-xdi-sync-endpoint)
+  - [tr-upload-cookies-from-csv](#tr-upload-cookies-from-csv)
     - [Authentication](#authentication-21)
     - [Arguments](#arguments-21)
     - [Usage](#usage-22)
+  - [tr-generate-api-keys](#tr-generate-api-keys)
+    - [Authentication](#authentication-22)
+    - [Arguments](#arguments-22)
+    - [Usage](#usage-23)
+  - [tr-build-xdi-sync-endpoint](#tr-build-xdi-sync-endpoint)
+    - [Authentication](#authentication-23)
+    - [Arguments](#arguments-23)
+    - [Usage](#usage-24)
 - [Proxy usage](#proxy-usage)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -131,7 +139,9 @@ yarn tr-mark-request-data-silos-completed --auth=$TRANSCEND_API_KEY
 yarn tr-skip-request-data-silos --auth=$TRANSCEND_API_KEY
 yarn tr-retry-request-data-silos --auth=$TRANSCEND_API_KEY
 yarn tr-update-consent-manager --auth=$TRANSCEND_API_KEY
-yarn tr-consent-managers-to-business-entities --auth=$TRANSCEND_API_KEY
+yarn tr-consent-managers-to-business-entities
+yarn tr-derive-data-silos-from-data-flows --auth=$TRANSCEND_API_KEY
+yarn tr-derive-data-silos-from-data-flows-cross-instance --auth=$TRANSCEND_API_KEY
 yarn tr-pull-consent-metrics --auth=$TRANSCEND_API_KEY
 yarn tr-upload-data-flows-from-csv --auth=$TRANSCEND_API_KEY
 yarn tr-upload-cookies-from-csv --auth=$TRANSCEND_API_KEY
@@ -162,7 +172,9 @@ tr-skip-request-data-silos --auth=$TRANSCEND_API_KEY
 tr-retry-request-data-silos --auth=$TRANSCEND_API_KEY
 tr-update-consent-manager --auth=$TRANSCEND_API_KEY
 tr-pull-consent-metrics --auth=$TRANSCEND_API_KEY
-tr-consent-managers-to-business-entities --auth=$TRANSCEND_API_KEY
+tr-consent-managers-to-business-entities
+tr-derive-data-silos-from-data-flows --auth=$TRANSCEND_API_KEY
+tr-derive-data-silos-from-data-flows-cross-instance --auth=$TRANSCEND_API_KEY
 tr-upload-data-flows-from-csv --auth=$TRANSCEND_API_KEY
 tr-generate-api-keys --auth=$TRANSCEND_API_KEY
 tr-build-xdi-sync-endpoint --auth=$TRANSCEND_API_KEY
@@ -1495,6 +1507,99 @@ Specify custom output file
 
 ```sh
 yarn tr-consent-managers-to-business-entities --consentManagerYmlFolder=./working/consent-managers/ --output=./custom.yml
+```
+
+### tr-derive-data-silos-from-data-flows
+
+Given a folder of data flow `transcend.yml` configurations, convert those configurations to set of data silo `transcend.yml` configurations.
+
+#### Authentication
+
+In order to use this cli, you will first need to generate an API key on the Transcend Admin Dashboard (https://app.transcend.io/infrastructure/api-keys).
+
+The API does not need any scopes, any API key will work.
+
+#### Arguments
+
+| Argument           | Description                                                                   | Type                 | Default                  | Required |
+| ------------------ | ----------------------------------------------------------------------------- | -------------------- | ------------------------ | -------- |
+| auth               | The Transcend API key with the scopes necessary for the command.              | string               | N/A                      | true     |
+| dataFlowsYmlFolder | The folder that contains data flow yml files                                  | string - folder-path | N/A                      | true     |
+| dataSilosYmlFolder | The folder that contains data silo yml files                                  | string - folder-path | N/A                      | true     |
+| ignoreYmls         | The set of yml files that should be skipped when uploading                    | string[]             | []                       | false    |
+| transcendUrl       | URL of the Transcend backend. Use https://api.us.transcend.io for US hosting. | string - URL         | https://api.transcend.io | false    |
+
+#### Usage
+
+Convert data flow configurations in folder `./working/data-flows/` to data silo configurations in folder `./working/data-silos/`
+
+```sh
+yarn tr-derive-data-silos-from-data-flows --auth=$TRANSCEND_API_KEY \
+ --dataFlowsYmlFolder=./working/data-flows/ \
+ --dataSilosYmlFolder=./working/data-silos/
+```
+
+Use with US backend
+
+```sh
+yarn tr-derive-data-silos-from-data-flows --auth=$TRANSCEND_API_KEY --transcendUrl=https://api.us.transcend.io \
+ --dataFlowsYmlFolder=./working/data-flows/ \
+ --dataSilosYmlFolder=./working/data-silos/
+```
+
+Skip a set of yml files
+
+```sh
+yarn tr-derive-data-silos-from-data-flows --auth=$TRANSCEND_API_KEY --ignoreYmls="Skip.yml,Other.yml" \
+ --dataFlowsYmlFolder=./working/data-flows/ \
+ --dataSilosYmlFolder=./working/data-silos/
+```
+
+### tr-derive-data-silos-from-data-flows-cross-instance
+
+Given a folder of data flow `transcend.yml` configurations, convert those configurations to a single `transcend.yml` configurations of all related data silos.
+
+#### Authentication
+
+In order to use this cli, you will first need to generate an API key on the Transcend Admin Dashboard (https://app.transcend.io/infrastructure/api-keys).
+
+The API does not need any scopes, any API key will work.
+
+#### Arguments
+
+| Argument           | Description                                                                   | Type                 | Default                  | Required |
+| ------------------ | ----------------------------------------------------------------------------- | -------------------- | ------------------------ | -------- |
+| auth               | The Transcend API key with the scopes necessary for the command.              | string               | N/A                      | true     |
+| dataFlowsYmlFolder | The folder that contains data flow yml files                                  | string - folder-path | N/A                      | true     |
+| output             | The output transcend.yml file containing the data silo configurations         | string - file-path   | ./transcend.yml          | false    |
+| ignoreYmls         | The set of yml files that should be skipped when uploading                    | string[]             | []                       | false    |
+| transcendUrl       | URL of the Transcend backend. Use https://api.us.transcend.io for US hosting. | string - URL         | https://api.transcend.io | false    |
+
+#### Usage
+
+Convert data flow configurations in folder `./working/data-flows/` to data silo configurations in file `./transcend.yml`
+
+```sh
+yarn tr-derive-data-silos-from-data-flows-cross-instance --auth=$TRANSCEND_API_KEY --dataFlowsYmlFolder=./working/data-flows/
+```
+
+Use with US backend
+
+```sh
+yarn tr-derive-data-silos-from-data-flows-cross-instance --auth=$TRANSCEND_API_KEY --dataFlowsYmlFolder=./working/data-flows/ \
+  --transcendUrl=https://api.us.transcend.io
+```
+
+Skip a set of yml files
+
+```sh
+yarn tr-derive-data-silos-from-data-flows-cross-instance --auth=$TRANSCEND_API_KEY --dataFlowsYmlFolder=./working/data-flows/ --ignoreYmls="Skip.yml,Other.yml"
+```
+
+Convert data flow configurations in folder `./working/data-flows/` to data silo configurations in file `./output.yml`
+
+```sh
+yarn tr-derive-data-silos-from-data-flows-cross-instance --auth=$TRANSCEND_API_KEY --dataFlowsYmlFolder=./working/data-flows/ --output=./output.yml
 ```
 
 ### tr-pull-consent-metrics

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/cli",
   "description": "Small package containing useful typescript utilities.",
-  "version": "4.74.0",
+  "version": "4.75.0",
   "homepage": "https://github.com/transcend-io/cli",
   "repository": {
     "type": "git",
@@ -15,6 +15,8 @@
     "tr-consent-managers-to-business-entities": "cli-consent-managers-to-business-entities.ts",
     "tr-cron-mark-identifiers-completed": "./build/cli-cron-mark-identifiers-completed.js",
     "tr-cron-pull-identifiers": "./build/cli-cron-pull-identifiers.js",
+    "tr-derive-data-silos-from-data-flows": "./build/cli-derive-data-silos-from-data-flows.js",
+    "tr-derive-data-silos-from-data-flows-cross-instance": "./build/cli-derive-data-silos-from-data-flows-cross-instance.js",
     "tr-discover-silos": "./build/cli-discover-silos.js",
     "tr-generate-api-keys": "./build/cli-generate-cross-account-api-keys.js",
     "tr-manual-enrichment-pull-identifiers": "./build/cli-manual-enrichment-pull-identifiers.js",

--- a/src/cli-consent-managers-to-business-entities.ts
+++ b/src/cli-consent-managers-to-business-entities.ts
@@ -38,7 +38,7 @@ function main(): void {
     process.exit(1);
   }
 
-  // Ensure file is passed
+  // Ensure folder is passed
   if (
     !existsSync(consentManagerYmlFolder) ||
     !lstatSync(consentManagerYmlFolder).isDirectory()

--- a/src/cli-derive-data-silos-from-data-flows-cross-instance.ts
+++ b/src/cli-derive-data-silos-from-data-flows-cross-instance.ts
@@ -1,0 +1,207 @@
+#!/usr/bin/env node
+import { fetchAndIndexCatalogs, buildTranscendGraphQLClient } from './graphql';
+import { join } from 'path';
+import yargs from 'yargs-parser';
+import difference from 'lodash/difference';
+import colors from 'colors';
+import { logger } from './logger';
+import { DEFAULT_TRANSCEND_API } from './constants';
+import { dataFlowsToDataSilos } from './consent-manager/dataFlowsToDataSilos';
+import { DataFlowInput } from './codecs';
+import { existsSync, lstatSync } from 'fs';
+import { listFiles } from './api-keys';
+import { readTranscendYaml, writeTranscendYaml } from './readTranscendYaml';
+import { splitCsvToList } from './requests';
+
+/**
+ * Derive the set of data silos from a set of data flows.
+ *
+ * Requires an API key - no scope required on API key
+ *
+ * Dev Usage:
+ * yarn ts-node ./src/cli-derive-data-silos-from-data-flows-cross-instance.ts --auth=$TRANSCEND_API_KEY \
+ *   --dataFlowsYmlFolder=./working/data-flows/ \
+ *   --output=./transcend.yml
+ *
+ * Standard usage:
+ * yarn tr-derive-data-silos-from-data-flows-cross-instance --auth=$TRANSCEND_API_KEY \
+ *   --dataFlowsYmlFolder=./working/data-flows/ \
+ *   --output=./transcend.yml
+ */
+async function main(): Promise<void> {
+  // Parse command line arguments
+  const {
+    transcendUrl = DEFAULT_TRANSCEND_API,
+    auth,
+    dataFlowsYmlFolder,
+    output = 'transcend.yml',
+    ignoreYmls = '',
+  } = yargs(process.argv.slice(2)) as { [k in string]: string };
+
+  // Ensure auth is passed
+  if (!auth) {
+    logger.error(
+      colors.red(
+        'A Transcend API key must be provided. You can specify using --auth=$TRANSCEND_API_KEY',
+      ),
+    );
+    process.exit(1);
+  }
+
+  // Ensure folder is passed to dataFlowsYmlFolder
+  if (!dataFlowsYmlFolder) {
+    logger.error(
+      colors.red(
+        'Missing required arg: --dataFlowsYmlFolder=./working/data-flows/',
+      ),
+    );
+    process.exit(1);
+  }
+
+  // Ensure folder is passed
+  if (
+    !existsSync(dataFlowsYmlFolder) ||
+    !lstatSync(dataFlowsYmlFolder).isDirectory()
+  ) {
+    logger.error(colors.red(`Folder does not exist: "${dataFlowsYmlFolder}"`));
+    process.exit(1);
+  }
+
+  // Ignore the data flows in these yml files
+  const instancesToIgnore = splitCsvToList(ignoreYmls).map(
+    (x) => x.split('.')[0],
+  );
+
+  // Map over each data flow yml file and convert to data silo configurations
+  const dataSiloInputs = listFiles(dataFlowsYmlFolder).map((directory) => {
+    // read in the data flows for a specific instance
+    const { 'data-flows': dataFlows = [] } = readTranscendYaml(
+      join(dataFlowsYmlFolder, directory),
+    );
+
+    // map the data flows to data silos
+    const { adTechDataSilos, siteTechDataSilos } = dataFlowsToDataSilos(
+      dataFlows as DataFlowInput[],
+      {
+        serviceToSupportedIntegration,
+        serviceToTitle,
+      },
+    );
+
+    return {
+      adTechDataSilos,
+      siteTechDataSilos,
+      organizationName: directory.split('.')[0],
+    };
+  });
+
+  // Mapping from service name to instances that have that service
+  const serviceToInstance: { [k in string]: string[] } = {};
+  dataSiloInputs.forEach(
+    ({ adTechDataSilos, siteTechDataSilos, organizationName }) => {
+      const allDataSilos = [...adTechDataSilos, ...siteTechDataSilos];
+      allDataSilos.forEach((dataSilo) => {
+        const service = dataSilo['outer-type'] || dataSilo.integrationName;
+        // create mapping to instance
+        if (!serviceToInstance[service]) {
+          serviceToInstance[service] = [];
+        }
+        serviceToInstance[service]!.push(organizationName);
+        serviceToInstance[service] = [...new Set(serviceToInstance[service])];
+      });
+    },
+  );
+
+  // List of ad tech integrations
+  const adTechIntegrations = [
+    ...new Set(
+      dataSiloInputs
+        .map(({ adTechDataSilos }) =>
+          adTechDataSilos.map(
+            (silo) => silo['outer-type'] || silo.integrationName,
+          ),
+        )
+        .flat(),
+    ),
+  ];
+
+  // List of site tech integrations
+  const siteTechIntegrations = difference(
+    [
+      ...new Set(
+        dataSiloInputs
+          .map(({ siteTechDataSilos }) =>
+            siteTechDataSilos.map(
+              (silo) => silo['outer-type'] || silo.integrationName,
+            ),
+          )
+          .flat(),
+      ),
+    ],
+    adTechIntegrations,
+  );
+
+  // Mapping from service name to list of
+  const serviceToFoundOnDomain: { [k in string]: string[] } = {};
+  dataSiloInputs.forEach(({ adTechDataSilos, siteTechDataSilos }) => {
+    const allDataSilos = [...adTechDataSilos, ...siteTechDataSilos];
+    allDataSilos.forEach((dataSilo) => {
+      const service = dataSilo['outer-type'] || dataSilo.integrationName;
+      const foundOnDomain = dataSilo.attributes?.find(
+        (attr) => attr.key === 'Found On Domain',
+      );
+      // create mapping to instance
+      if (!serviceToFoundOnDomain[service]) {
+        serviceToFoundOnDomain[service] = [];
+      }
+      serviceToFoundOnDomain[service]!.push(...(foundOnDomain?.values || []));
+      serviceToFoundOnDomain[service] = [
+        ...new Set(serviceToFoundOnDomain[service]),
+      ];
+    });
+  });
+
+  // Fetch all integrations in the catalog
+  const client = buildTranscendGraphQLClient(transcendUrl, auth);
+  const { serviceToTitle, serviceToSupportedIntegration } =
+    await fetchAndIndexCatalogs(client);
+
+  // construct the aggregated data silo inputs
+  const dataSilos = [...adTechIntegrations, ...siteTechIntegrations].map(
+    (service) => ({
+      title: serviceToTitle[service],
+      ...(serviceToSupportedIntegration[service]
+        ? { integrationName: service }
+        : { integrationName: 'promptAPerson', 'outer-type': service }),
+      attributes: [
+        {
+          key: 'Tech Type',
+          values: ['Ad Tech'],
+        },
+        {
+          key: 'Business Units',
+          values: difference(
+            serviceToInstance[service] || [],
+            instancesToIgnore,
+          ),
+        },
+        {
+          key: 'Found On Domain',
+          values: serviceToFoundOnDomain[service] || [],
+        },
+      ],
+    }),
+  );
+
+  // Log output
+  logger.log(`Total Services: ${dataSilos.length}`);
+  logger.log(`Ad Tech Services: ${adTechIntegrations.length}`);
+  logger.log(`Site Tech Services: ${siteTechIntegrations.length}`);
+
+  // Write to yaml
+  writeTranscendYaml(output, {
+    'data-silos': dataSilos,
+  });
+}
+
+main();

--- a/src/cli-derive-data-silos-from-data-flows.ts
+++ b/src/cli-derive-data-silos-from-data-flows.ts
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+import { fetchAndIndexCatalogs, buildTranscendGraphQLClient } from './graphql';
+import { join } from 'path';
+import yargs from 'yargs-parser';
+import colors from 'colors';
+
+import { logger } from './logger';
+import { DEFAULT_TRANSCEND_API } from './constants';
+import { dataFlowsToDataSilos } from './consent-manager/dataFlowsToDataSilos';
+import { DataFlowInput } from './codecs';
+import { splitCsvToList } from './requests';
+import { existsSync, lstatSync } from 'fs';
+import { listFiles } from './api-keys';
+import { readTranscendYaml, writeTranscendYaml } from './readTranscendYaml';
+
+/**
+ * Derive the set of data silos that can be derived from a set of data flows.
+ *
+ * Requires an API key - no scope required on API key
+ *
+ * Dev Usage:
+ * yarn ts-node ./src/cli-derive-data-silos-from-data-flows.ts --auth=$TRANSCEND_API_KEY \
+ *   --dataFlowsYmlFolder=./working/data-flows/ \
+ *   --dataSilosYmlFolder=./working/data-silos/
+ *
+ * Standard usage:
+ * yarn tr-derive-data-silos-from-data-flows --auth=$TRANSCEND_API_KEY \
+ *   --dataFlowsYmlFolder=./working/data-flows/ \
+ *   --dataSilosYmlFolder=./working/data-silos/
+ */
+async function main(): Promise<void> {
+  // Parse command line arguments
+  const {
+    transcendUrl = DEFAULT_TRANSCEND_API,
+    auth,
+    dataFlowsYmlFolder,
+    dataSilosYmlFolder,
+    ignoreYmls = '',
+  } = yargs(process.argv.slice(2)) as { [k in string]: string };
+
+  // Ensure auth is passed
+  if (!auth) {
+    logger.error(
+      colors.red(
+        'A Transcend API key must be provided. You can specify using --auth=$TRANSCEND_API_KEY',
+      ),
+    );
+    process.exit(1);
+  }
+
+  // Ensure folder is passed to dataFlowsYmlFolder
+  if (!dataFlowsYmlFolder) {
+    logger.error(
+      colors.red(
+        'Missing required arg: --dataFlowsYmlFolder=./working/data-flows/',
+      ),
+    );
+    process.exit(1);
+  }
+
+  // Ensure folder is passed
+  if (
+    !existsSync(dataFlowsYmlFolder) ||
+    !lstatSync(dataFlowsYmlFolder).isDirectory()
+  ) {
+    logger.error(colors.red(`Folder does not exist: "${dataFlowsYmlFolder}"`));
+    process.exit(1);
+  }
+
+  // Ensure folder is passed to dataSilosYmlFolder
+  if (!dataSilosYmlFolder) {
+    logger.error(
+      colors.red(
+        'Missing required arg: --dataSilosYmlFolder=./working/data-silos/',
+      ),
+    );
+    process.exit(1);
+  }
+
+  // Ensure folder is passed
+  if (
+    !existsSync(dataSilosYmlFolder) ||
+    !lstatSync(dataSilosYmlFolder).isDirectory()
+  ) {
+    logger.error(colors.red(`Folder does not exist: "${dataSilosYmlFolder}"`));
+    process.exit(1);
+  }
+
+  // Ignore the data flows in these yml files
+  const ymlsToIgnore = splitCsvToList(ignoreYmls);
+
+  // Fetch all integrations in the catalog
+  const client = buildTranscendGraphQLClient(transcendUrl, auth);
+  const { serviceToTitle, serviceToSupportedIntegration } =
+    await fetchAndIndexCatalogs(client);
+
+  // List of each data flow yml file
+  listFiles(dataFlowsYmlFolder).forEach((directory) => {
+    // read in the data flows for a specific instance
+    const { 'data-flows': dataFlows = [] } = readTranscendYaml(
+      join(dataFlowsYmlFolder, directory),
+    );
+
+    // map the data flows to data silos
+    const { adTechDataSilos, siteTechDataSilos } = dataFlowsToDataSilos(
+      dataFlows as DataFlowInput[],
+      {
+        serviceToSupportedIntegration,
+        serviceToTitle,
+      },
+    );
+
+    // combine and write to yml file
+    const dataSilos = [...adTechDataSilos, ...siteTechDataSilos];
+    logger.log(`Total Services: ${dataSilos.length}`);
+    logger.log(`Ad Tech Services: ${adTechDataSilos.length}`);
+    logger.log(`Site Tech Services: ${siteTechDataSilos.length}`);
+    writeTranscendYaml(join(dataSilosYmlFolder, directory), {
+      'data-silos': ymlsToIgnore.includes(directory) ? [] : dataSilos,
+    });
+  });
+}
+
+main();

--- a/src/consent-manager/dataFlowsToDataSilos.ts
+++ b/src/consent-manager/dataFlowsToDataSilos.ts
@@ -1,0 +1,124 @@
+import { DataFlowInput, DataSiloInput } from '../codecs';
+import union from 'lodash/union';
+import { IndexedCatalogs } from '../graphql';
+
+/**
+ * Convert data flow configurations into a set of data silo configurations
+ *
+ * @param inputs - Data flow input to convert to data silos
+ * @param options - Additional options
+ * @returns Business entity configuration input
+ */
+export function dataFlowsToDataSilos(
+  inputs: DataFlowInput[],
+  {
+    adTechPurposes = ['SaleOfInfo'],
+    serviceToTitle,
+    serviceToSupportedIntegration,
+  }: IndexedCatalogs & {
+    /** List of purposes that are considered "Ad Tech"  */
+    adTechPurposes?: string[];
+  },
+): {
+  /** List of data silo configurations for site-tech services */
+  siteTechDataSilos: DataSiloInput[];
+  /** List of data silo configurations for ad-tech services */
+  adTechDataSilos: DataSiloInput[];
+} {
+  // List of site tech integrations
+  let siteTechIntegrations: string[] = [];
+
+  // List of ad tech integrations
+  const adTechIntegrations: string[] = [];
+
+  // Mapping from service name to list of
+  const serviceToFoundOnDomain: { [k in string]: string[] } = {};
+
+  // iterate over each flow
+  inputs.forEach((flow) => {
+    // process data flows with services
+    const { service, attributes = [] } = flow;
+    if (!service || service === 'internalService') {
+      return;
+    }
+
+    // create mapping to found on domain
+    const foundOnDomain = attributes.find(
+      (attr) => attr.key === 'Found on Domain',
+    );
+
+    // Create a list of all domains where the data flow was found
+    if (foundOnDomain) {
+      if (!serviceToFoundOnDomain[service]) {
+        serviceToFoundOnDomain[service] = [];
+      }
+      serviceToFoundOnDomain[service]!.push(
+        ...foundOnDomain.values.map((v) =>
+          v.replace('https://', '').replace('http://', ''),
+        ),
+      );
+      serviceToFoundOnDomain[service] = [
+        ...new Set(serviceToFoundOnDomain[service]),
+      ];
+    }
+
+    // Keep track of ad tech
+    if (union(flow.trackingPurposes, adTechPurposes).length > 0) {
+      // add service to ad tech list
+      adTechIntegrations.push(service);
+
+      // remove from site tech list
+      if (siteTechIntegrations.includes(service)) {
+        siteTechIntegrations = siteTechIntegrations.filter(
+          (s) => s !== service,
+        );
+      }
+    } else if (!adTechIntegrations.includes(service)) {
+      // add to site tech list
+      siteTechIntegrations.push(service);
+    }
+  });
+
+  // create the list of ad tech integrations
+  const adTechDataSilos = [...new Set(adTechIntegrations)].map((service) => ({
+    title: serviceToTitle[service],
+    ...(serviceToSupportedIntegration[service]
+      ? { integrationName: service }
+      : { integrationName: 'promptAPerson', 'outer-type': service }),
+    attributes: [
+      {
+        key: 'Tech Type',
+        values: ['Ad Tech'],
+      },
+      {
+        key: 'Found On Domain',
+        values: serviceToFoundOnDomain[service] || [],
+      },
+    ],
+  }));
+
+  // create the list of site tech integrations
+  const siteTechDataSilos = [...new Set(siteTechIntegrations)].map(
+    (service) => ({
+      title: serviceToTitle[service],
+      ...(serviceToSupportedIntegration[service]
+        ? { integrationName: service }
+        : { integrationName: 'promptAPerson', outerType: service }),
+      attributes: [
+        {
+          key: 'Tech Type',
+          values: ['Site Tech'],
+        },
+        {
+          key: 'Found On Domain',
+          values: serviceToFoundOnDomain[service] || [],
+        },
+      ],
+    }),
+  );
+
+  return {
+    siteTechDataSilos,
+    adTechDataSilos,
+  };
+}

--- a/src/graphql/fetchCatalogs.ts
+++ b/src/graphql/fetchCatalogs.ts
@@ -47,3 +47,48 @@ export async function fetchAllCatalogs(
   } while (shouldContinue);
   return catalogs;
 }
+
+export interface IndexedCatalogs {
+  /** Mapping from service name to service title */
+  serviceToTitle: { [k in string]: string };
+  /** Mapping from service name to boolean indicate if service has API integration support */
+  serviceToSupportedIntegration: { [k in string]: boolean };
+}
+
+/**
+ * Fetch all integration catalogs and index them for usage in common utility manners
+ *
+ * @param client - Client
+ * @returns Integration catalogs
+ */
+export async function fetchAndIndexCatalogs(client: GraphQLClient): Promise<
+  {
+    /** List of all catalogs */
+    catalogs: Catalog[];
+  } & IndexedCatalogs
+> {
+  // Fetch all integrations in the catalog
+  const catalogs = await fetchAllCatalogs(client);
+
+  // Create mapping from service name to service title
+  const serviceToTitle = catalogs.reduce(
+    (acc, catalog) =>
+      Object.assign(acc, { [catalog.integrationName]: catalog.title }),
+    {} as { [k in string]: string },
+  );
+
+  // Create mapping from service name to boolean indicate if service has API integration support
+  const serviceToSupportedIntegration = catalogs.reduce(
+    (acc, catalog) =>
+      Object.assign(acc, {
+        [catalog.integrationName]: catalog.hasApiFunctionality,
+      }),
+    {} as { [k in string]: boolean },
+  );
+
+  return {
+    catalogs,
+    serviceToTitle,
+    serviceToSupportedIntegration,
+  };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -458,6 +458,8 @@ __metadata:
     tr-consent-managers-to-business-entities: cli-consent-managers-to-business-entities.ts
     tr-cron-mark-identifiers-completed: ./build/cli-cron-mark-identifiers-completed.js
     tr-cron-pull-identifiers: ./build/cli-cron-pull-identifiers.js
+    tr-derive-data-silos-from-data-flows: ./build/cli-derive-data-silos-from-data-flows.js
+    tr-derive-data-silos-from-data-flows-cross-instance: ./build/cli-derive-data-silos-from-data-flows-cross-instance.js
     tr-discover-silos: ./build/cli-discover-silos.js
     tr-generate-api-keys: ./build/cli-generate-cross-account-api-keys.js
     tr-manual-enrichment-pull-identifiers: ./build/cli-manual-enrichment-pull-identifiers.js


### PR DESCRIPTION
### tr-derive-data-silos-from-data-flows

Given a folder of data flow `transcend.yml` configurations, convert those configurations to set of data silo `transcend.yml` configurations.

#### Authentication

In order to use this cli, you will first need to generate an API key on the Transcend Admin Dashboard (https://app.transcend.io/infrastructure/api-keys).

The API does not need any scopes, any API key will work.

#### Arguments

| Argument           | Description                                                                   | Type                 | Default                  | Required |
| ------------------ | ----------------------------------------------------------------------------- | -------------------- | ------------------------ | -------- |
| auth               | The Transcend API key with the scopes necessary for the command.              | string               | N/A                      | true     |
| dataFlowsYmlFolder | The folder that contains data flow yml files                                  | string - folder-path | N/A                      | true     |
| dataSilosYmlFolder | The folder that contains data silo yml files                                  | string - folder-path | N/A                      | true     |
| ignoreYmls         | The set of yml files that should be skipped when uploading                    | string[]             | []                       | false    |
| transcendUrl       | URL of the Transcend backend. Use https://api.us.transcend.io for US hosting. | string - URL         | https://api.transcend.io | false    |

#### Usage

Convert data flow configurations in folder `./working/data-flows/` to data silo configurations in folder `./working/data-silos/`

```sh
yarn tr-derive-data-silos-from-data-flows --auth=$TRANSCEND_API_KEY \
 --dataFlowsYmlFolder=./working/data-flows/ \
 --dataSilosYmlFolder=./working/data-silos/
```

Use with US backend

```sh
yarn tr-derive-data-silos-from-data-flows --auth=$TRANSCEND_API_KEY --transcendUrl=https://api.us.transcend.io \
 --dataFlowsYmlFolder=./working/data-flows/ \
 --dataSilosYmlFolder=./working/data-silos/
```

Skip a set of yml files

```sh
yarn tr-derive-data-silos-from-data-flows --auth=$TRANSCEND_API_KEY --ignoreYmls="Skip.yml,Other.yml" \
 --dataFlowsYmlFolder=./working/data-flows/ \
 --dataSilosYmlFolder=./working/data-silos/
```

### tr-derive-data-silos-from-data-flows-cross-instance

Given a folder of data flow `transcend.yml` configurations, convert those configurations to a single `transcend.yml` configurations of all related data silos.

#### Authentication

In order to use this cli, you will first need to generate an API key on the Transcend Admin Dashboard (https://app.transcend.io/infrastructure/api-keys).

The API does not need any scopes, any API key will work.

#### Arguments

| Argument           | Description                                                                   | Type                 | Default                  | Required |
| ------------------ | ----------------------------------------------------------------------------- | -------------------- | ------------------------ | -------- |
| auth               | The Transcend API key with the scopes necessary for the command.              | string               | N/A                      | true     |
| dataFlowsYmlFolder | The folder that contains data flow yml files                                  | string - folder-path | N/A                      | true     |
| output             | The output transcend.yml file containing the data silo configurations         | string - file-path   | ./transcend.yml          | false    |
| ignoreYmls         | The set of yml files that should be skipped when uploading                    | string[]             | []                       | false    |
| transcendUrl       | URL of the Transcend backend. Use https://api.us.transcend.io for US hosting. | string - URL         | https://api.transcend.io | false    |

#### Usage

Convert data flow configurations in folder `./working/data-flows/` to data silo configurations in file `./transcend.yml`

```sh
yarn tr-derive-data-silos-from-data-flows-cross-instance --auth=$TRANSCEND_API_KEY --dataFlowsYmlFolder=./working/data-flows/
```

Use with US backend

```sh
yarn tr-derive-data-silos-from-data-flows-cross-instance --auth=$TRANSCEND_API_KEY --dataFlowsYmlFolder=./working/data-flows/ \
  --transcendUrl=https://api.us.transcend.io
```

Skip a set of yml files

```sh
yarn tr-derive-data-silos-from-data-flows-cross-instance --auth=$TRANSCEND_API_KEY --dataFlowsYmlFolder=./working/data-flows/ --ignoreYmls="Skip.yml,Other.yml"
```

Convert data flow configurations in folder `./working/data-flows/` to data silo configurations in file `./output.yml`

```sh
yarn tr-derive-data-silos-from-data-flows-cross-instance --auth=$TRANSCEND_API_KEY --dataFlowsYmlFolder=./working/data-flows/ --output=./output.yml
```
