### PR TITLE
`tr-consent-manager-service-json-to-yml` - upload `await airgap.getMetadata()` to Transcend

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,34 +77,38 @@
     - [Authentication](#authentication-16)
     - [Arguments](#arguments-16)
     - [Usage](#usage-17)
-  - [tr-derive-data-silos-from-data-flows](#tr-derive-data-silos-from-data-flows)
+  - [tr-consent-manager-service-json-to-yml](#tr-consent-manager-service-json-to-yml)
     - [Authentication](#authentication-17)
     - [Arguments](#arguments-17)
     - [Usage](#usage-18)
-  - [tr-derive-data-silos-from-data-flows-cross-instance](#tr-derive-data-silos-from-data-flows-cross-instance)
+  - [tr-derive-data-silos-from-data-flows](#tr-derive-data-silos-from-data-flows)
     - [Authentication](#authentication-18)
     - [Arguments](#arguments-18)
     - [Usage](#usage-19)
-  - [tr-pull-consent-metrics](#tr-pull-consent-metrics)
+  - [tr-derive-data-silos-from-data-flows-cross-instance](#tr-derive-data-silos-from-data-flows-cross-instance)
     - [Authentication](#authentication-19)
     - [Arguments](#arguments-19)
     - [Usage](#usage-20)
-  - [tr-upload-data-flows-from-csv](#tr-upload-data-flows-from-csv)
+  - [tr-pull-consent-metrics](#tr-pull-consent-metrics)
     - [Authentication](#authentication-20)
     - [Arguments](#arguments-20)
     - [Usage](#usage-21)
-  - [tr-upload-cookies-from-csv](#tr-upload-cookies-from-csv)
+  - [tr-upload-data-flows-from-csv](#tr-upload-data-flows-from-csv)
     - [Authentication](#authentication-21)
     - [Arguments](#arguments-21)
     - [Usage](#usage-22)
-  - [tr-generate-api-keys](#tr-generate-api-keys)
+  - [tr-upload-cookies-from-csv](#tr-upload-cookies-from-csv)
     - [Authentication](#authentication-22)
     - [Arguments](#arguments-22)
     - [Usage](#usage-23)
-  - [tr-build-xdi-sync-endpoint](#tr-build-xdi-sync-endpoint)
+  - [tr-generate-api-keys](#tr-generate-api-keys)
     - [Authentication](#authentication-23)
     - [Arguments](#arguments-23)
     - [Usage](#usage-24)
+  - [tr-build-xdi-sync-endpoint](#tr-build-xdi-sync-endpoint)
+    - [Authentication](#authentication-24)
+    - [Arguments](#arguments-24)
+    - [Usage](#usage-25)
 - [Proxy usage](#proxy-usage)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -140,6 +144,7 @@ yarn tr-skip-request-data-silos --auth=$TRANSCEND_API_KEY
 yarn tr-retry-request-data-silos --auth=$TRANSCEND_API_KEY
 yarn tr-update-consent-manager --auth=$TRANSCEND_API_KEY
 yarn tr-consent-managers-to-business-entities
+yarn tr-consent-manager-service-json-to-yml
 yarn tr-derive-data-silos-from-data-flows --auth=$TRANSCEND_API_KEY
 yarn tr-derive-data-silos-from-data-flows-cross-instance --auth=$TRANSCEND_API_KEY
 yarn tr-pull-consent-metrics --auth=$TRANSCEND_API_KEY
@@ -173,6 +178,7 @@ tr-retry-request-data-silos --auth=$TRANSCEND_API_KEY
 tr-update-consent-manager --auth=$TRANSCEND_API_KEY
 tr-pull-consent-metrics --auth=$TRANSCEND_API_KEY
 tr-consent-managers-to-business-entities
+tr-consent-manager-service-json-to-yml
 tr-derive-data-silos-from-data-flows --auth=$TRANSCEND_API_KEY
 tr-derive-data-silos-from-data-flows-cross-instance --auth=$TRANSCEND_API_KEY
 tr-upload-data-flows-from-csv --auth=$TRANSCEND_API_KEY
@@ -1507,6 +1513,41 @@ Specify custom output file
 
 ```sh
 yarn tr-consent-managers-to-business-entities --consentManagerYmlFolder=./working/consent-managers/ --output=./custom.yml
+```
+
+### tr-consent-manager-service-json-to-yml
+
+Import the services from an airgap.js file into a Transcend instance.
+
+Step 1) Run `await airgap.getMetadata()` on a site with airgap
+Step 2) Right click on the printed object, and click `Copy object`
+Step 3) Place output of file in a file named `services.json`
+Step 4) Run `yarn tr-consent-manager-service-json-to-yml --file=./services.json --output=./transcend.yml`
+Step 5) Run `yarn tr-push --auth=$TRANSCEND_API_KEY --file=./transcend.yml --classifyService=true`
+
+#### Authentication
+
+No authentication is required to run this command. It reads and writes files from local disk.
+
+#### Arguments
+
+| Argument | Description                                                              | Type               | Default         | Required |
+| -------- | ------------------------------------------------------------------------ | ------------------ | --------------- | -------- |
+| file     | Path to the `services.json` file, output of `await airgap.getMetadata()` | string - file-path | ./services.json | false    |
+| output   | Path to the output `transcend.yml` to write to                           | string - file-path | ./transcend.yml | false    |
+
+#### Usage
+
+Convert data flow configurations in folder `./services.json` to yml in `./transcend.yml`
+
+```sh
+yarn tr-consent-manager-service-json-to-yml
+```
+
+With file locations
+
+```sh
+yarn tr-consent-manager-service-json-to-yml --file=./folder/services.json --output./folder/transcend.yml
 ```
 
 ### tr-derive-data-silos-from-data-flows

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/cli",
   "description": "Small package containing useful typescript utilities.",
-  "version": "4.75.0",
+  "version": "4.76.0",
   "homepage": "https://github.com/transcend-io/cli",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "main": "build/index",
   "bin": {
     "tr-build-xdi-sync-endpoint": "./build/cli-build-xdi-sync-endpoint.js",
+    "tr-consent-manager-service-json-to-yml": "./build/cli-consent-manager-service-json-to-yml.js",
     "tr-consent-managers-to-business-entities": "cli-consent-managers-to-business-entities.ts",
     "tr-cron-mark-identifiers-completed": "./build/cli-cron-mark-identifiers-completed.js",
     "tr-cron-pull-identifiers": "./build/cli-cron-pull-identifiers.js",
@@ -32,7 +33,6 @@
     "tr-request-upload": "./build/cli-request-upload.js",
     "tr-retry-request-data-silos": "./build/cli-retry-request-data-silos.js",
     "tr-skip-request-data-silos": "./build/cli-skip-request-data-silos.js",
-    "tr-consent-manager-service-json-to-yml": "./build/cli-consent-manager-service-json-to-yml.js",
     "tr-update-consent-manager": "./build/cli-update-consent-manager-to-latest.js",
     "tr-upload-cookies-from-csv": "./build/cli-upload-cookies-from-csv.js",
     "tr-upload-data-flows-from-csv": "./build/cli-upload-data-flows-from-csv.js"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/cli",
   "description": "Small package containing useful typescript utilities.",
-  "version": "4.77.0",
+  "version": "4.78.0",
   "homepage": "https://github.com/transcend-io/cli",
   "repository": {
     "type": "git",

--- a/src/cli-consent-manager-service-json-to-yml.ts
+++ b/src/cli-consent-manager-service-json-to-yml.ts
@@ -1,0 +1,83 @@
+#!/usr/bin/env/node
+import * as t from 'io-ts';
+import { writeTranscendYaml } from './readTranscendYaml';
+import yargs from 'yargs-parser';
+import colors from 'colors';
+import { logger } from './logger';
+import { existsSync, readFileSync } from 'fs';
+import { decodeCodec } from '@transcend-io/type-utils';
+import {
+  ConsentManagerServiceMetadata,
+  CookieInput,
+  DataFlowInput,
+} from './codecs';
+
+/**
+ * Take the output of (await airgap.getMetadata()).services and format into
+ * a yaml file that tr-push can push up
+ *
+ * yarn ts-node ./src/cli-consent-manager-service-json-to-yml.ts \
+ *   --file=./services.json \
+ *   --output=./transcend.yml
+ *
+ * Standard usage:
+ * yarn tr-consent-manager-service-json-to-yml \
+ *   --file=./services.json \
+ *   --output=./transcend.yml
+ */
+function main(): void {
+  // Parse command line arguments
+  const { file = './services.json', output = './transcend.yml' } = yargs(
+    process.argv.slice(2),
+  ) as { [k in string]: string };
+
+  // Ensure files exist
+  if (!existsSync(file)) {
+    logger.error(colors.red(`File does not exist: --file="${file}"`));
+    process.exit(1);
+  }
+  if (!existsSync(output)) {
+    logger.error(colors.red(`File does not exist: --output="${output}"`));
+    process.exit(1);
+  }
+
+  // Read in each consent manager configuration
+  const services = decodeCodec(
+    t.array(ConsentManagerServiceMetadata),
+    readFileSync(file),
+  );
+
+  // Create data flows and cookie configurations
+  const dataFlows: DataFlowInput[] = [];
+  const cookies: CookieInput[] = [];
+  services.forEach((service) => {
+    service.dataFlows.forEach((dataFlow) => {
+      dataFlows.push({
+        value: dataFlow.value,
+        type: dataFlow.type,
+        trackingPurposes: dataFlow.trackingPurposes,
+      });
+    });
+
+    service.cookies.forEach((cookie) => {
+      cookies.push({
+        name: cookie.name,
+        trackingPurposes: cookie.trackingPurposes,
+      });
+    });
+  });
+
+  // write to disk
+  writeTranscendYaml(output, {
+    'data-flows': dataFlows,
+    cookies,
+  });
+
+  logger.info(
+    colors.green(
+      `Successfully wrote ${dataFlows.length} data flows and ${cookies.length} cookies to file "${output}"`,
+    ),
+  );
+}
+
+main();

--- a/src/codecs.ts
+++ b/src/codecs.ts
@@ -871,3 +871,38 @@ export const CookieCsvInput = t.intersection([
 
 /** Type override */
 export type CookieCsvInput = t.TypeOf<typeof CookieCsvInput>;
+
+/**
+ * Export of (await airgap.getMetadata()).services
+ */
+export const ConsentManagerServiceMetadata = t.type({
+  /** The title of the service */
+  title: t.string,
+  /** The description */
+  description: t.string,
+  /** Cookies */
+  cookies: t.array(
+    t.type({
+      /** Name of cookie */
+      name: t.string,
+      /** Allowed purposes */
+      trackingPurposes: t.array(t.string),
+    }),
+  ),
+  /** Data Flows */
+  dataFlows: t.array(
+    t.type({
+      /** Value of data flow */
+      value: t.string,
+      /** Type of data flow */
+      type: valuesOf(DataFlowScope),
+      /** Allowed purposes */
+      trackingPurposes: t.array(t.string),
+    }),
+  ),
+});
+
+/** Type override */
+export type ConsentManagerServiceMetadata = t.TypeOf<
+  typeof ConsentManagerServiceMetadata
+>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -455,6 +455,7 @@ __metadata:
     yargs-parser: ^21.1.1
   bin:
     tr-build-xdi-sync-endpoint: ./build/cli-build-xdi-sync-endpoint.js
+    tr-consent-manager-service-json-to-yml: ./build/cli-consent-manager-service-json-to-yml.js
     tr-consent-managers-to-business-entities: cli-consent-managers-to-business-entities.ts
     tr-cron-mark-identifiers-completed: ./build/cli-cron-mark-identifiers-completed.js
     tr-cron-pull-identifiers: ./build/cli-cron-pull-identifiers.js


### PR DESCRIPTION
### tr-consent-manager-service-json-to-yml

Import the services from an airgap.js file into a Transcend instance.

Step 1) Run `await airgap.getMetadata()` on a site with airgap
Step 2) Right click on the printed object, and click `Copy object`
Step 3) Place output of file in a file named `services.json`
Step 4) Run `yarn tr-consent-manager-service-json-to-yml --file=./services.json --output=./transcend.yml`
Step 5) Run `yarn tr-push --auth=$TRANSCEND_API_KEY --file=./transcend.yml --classifyService=true`

#### Authentication

No authentication is required to run this command. It reads and writes files from local disk.

#### Arguments

| Argument | Description                                                              | Type               | Default         | Required |
| -------- | ------------------------------------------------------------------------ | ------------------ | --------------- | -------- |
| file     | Path to the `services.json` file, output of `await airgap.getMetadata()` | string - file-path | ./services.json | false    |
| output   | Path to the output `transcend.yml` to write to                           | string - file-path | ./transcend.yml | false    |

#### Usage

Convert data flow configurations in folder `./services.json` to yml in `./transcend.yml`

```sh
yarn tr-consent-manager-service-json-to-yml
```

With file locations

```sh
yarn tr-consent-manager-service-json-to-yml --file=./folder/services.json --output./folder/transcend.yml
```