### PR TITLE
make pathfinder types generic

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/cli",
   "description": "Small package containing useful typescript utilities.",
-  "version": "4.78.0",
+  "version": "4.80.0",
   "homepage": "https://github.com/transcend-io/cli",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/cli",
   "description": "Small package containing useful typescript utilities.",
-  "version": "4.79.0",
+  "version": "4.80.0",
   "homepage": "https://github.com/transcend-io/cli",
   "repository": {
     "type": "git",

--- a/pathfinder-policy-yml-schema.json
+++ b/pathfinder-policy-yml-schema.json
@@ -19,7 +19,14 @@
                 "required": ["routeName", "enabledPolicies"],
                 "properties": {
                   "routeName": {
-                    "const": "/v1/chat/completions"
+                    "anyOf": [
+                      {
+                        "const": "/v1/chat/completions"
+                      },
+                      {
+                        "const": "/v1/embeddings"
+                      }
+                    ]
                   },
                   "enabledPolicies": {
                     "type": "array",

--- a/src/codecs.ts
+++ b/src/codecs.ts
@@ -955,7 +955,7 @@ export const OpenAIEnabledRoute = buildEnabledRouteType({
 /** Type override */
 export type OpenAIEnabledRoute = t.TypeOf<typeof OpenAIEnabledRoute>;
 
-export const OpenAIIntegration = buildAIIntegrationType({
+export const OpenAIIntegration = buildAIIntegrationType<OpenAIRouteName>({
   TEnabledRoutes: t.array(OpenAIEnabledRoute),
 });
 

--- a/src/codecs.ts
+++ b/src/codecs.ts
@@ -955,8 +955,13 @@ export const OpenAIEnabledRoute = buildEnabledRouteType({
 /** Type override */
 export type OpenAIEnabledRoute = t.TypeOf<typeof OpenAIEnabledRoute>;
 
-export const OpenAIIntegration = buildAIIntegrationType<OpenAIRouteName>({
-  TEnabledRoutes: t.array(OpenAIEnabledRoute),
+export const OpenAIEnabledRoutes = t.array(OpenAIEnabledRoute);
+
+  /** Type override */
+  export type OpenAIEnabledRoutes = t.TypeOf<typeof OpenAIEnabledRoutes>;
+
+export const OpenAIIntegration = buildAIIntegrationType<OpenAIRouteName, OpenAIEnabledRoutes>({
+  TEnabledRoutes: OpenAIEnabledRoutes,
 });
 
 /** Type override */

--- a/src/codecs.ts
+++ b/src/codecs.ts
@@ -940,15 +940,18 @@ export type AIIntegrationC<T extends t.Mixed> = t.TypeC<{
 }>;
 
 /** The codec of OpenAI routeName */
-export type OpenAIRouteNameC = t.LiteralC<'/v1/chat/completions'>;
+export type OpenAIRouteNameC = t.UnionC<
+  [t.LiteralC<'/v1/chat/completions'>, t.LiteralC<'/v1/embeddings'>]
+>;
 
 /**
  * The names of the OpenAI routes that we support setting policies for
  * reference: https://platform.openai.com/docs/api-reference/introduction
  */
-export const OpenAIRouteName: OpenAIRouteNameC = t.literal(
-  '/v1/chat/completions',
-);
+export const OpenAIRouteName: OpenAIRouteNameC = t.union([
+  t.literal('/v1/chat/completions'),
+  t.literal('/v1/embeddings'),
+]);
 
 /** Type override */
 export type OpenAIRouteName = t.TypeOf<typeof OpenAIRouteName>;

--- a/src/codecs.ts
+++ b/src/codecs.ts
@@ -940,14 +940,14 @@ export type AIIntegrationC<T extends t.Mixed> = t.TypeC<{
 }>;
 
 /** The codec of OpenAI routeName */
-export type OpenAIRouteNameC = t.LiteralC<'/v1/chat/completions'>
+export type OpenAIRouteNameC = t.LiteralC<'/v1/chat/completions'>;
 
 /**
  * The names of the OpenAI routes that we support setting policies for
  * reference: https://platform.openai.com/docs/api-reference/introduction
  */
 export const OpenAIRouteName: OpenAIRouteNameC = t.literal(
-  '/v1/chat/completions'
+  '/v1/chat/completions',
 );
 
 /** Type override */
@@ -961,7 +961,8 @@ export const OpenAIEnabledRoute = buildEnabledRouteType({
 export type OpenAIEnabledRoute = t.TypeOf<typeof OpenAIEnabledRoute>;
 
 /** The enabled routes for OpenAI */
-export const OpenAIEnabledRoutes: EnabledRoutesC<OpenAIRouteNameC> = t.array(OpenAIEnabledRoute);
+export const OpenAIEnabledRoutes: EnabledRoutesC<OpenAIRouteNameC> =
+  t.array(OpenAIEnabledRoute);
   
 /** Type override */
 export type OpenAIEnabledRoutes = t.TypeOf<typeof OpenAIEnabledRoutes>;

--- a/src/codecs.ts
+++ b/src/codecs.ts
@@ -939,11 +939,13 @@ export type AIIntegrationC<T extends t.Mixed> = t.TypeC<{
   enabledRoutes: EnabledRoutesC<T>;
 }>;
 
+export type OpenAIRouteNameC = t.LiteralC<'/v1/chat/completions'>
+
 /**
  * The names of the OpenAI routes that we support setting policies for
  * reference: https://platform.openai.com/docs/api-reference/introduction
  */
-export const OpenAIRouteName = t.literal('/v1/chat/completions');
+export const OpenAIRouteName: OpenAIRouteNameC = t.literal('/v1/chat/completions');
 
 /** Type override */
 export type OpenAIRouteName = t.TypeOf<typeof OpenAIRouteName>;
@@ -955,8 +957,13 @@ export const OpenAIEnabledRoute = buildEnabledRouteType({
 /** Type override */
 export type OpenAIEnabledRoute = t.TypeOf<typeof OpenAIEnabledRoute>;
 
-export const OpenAIIntegration = buildAIIntegrationType<OpenAIRouteName, t.array(OpenAIEnabledRoute)>({
-  TEnabledRoutes: t.array(OpenAIEnabledRoute),
+export const OpenAIEnabledRoutes = t.array(OpenAIEnabledRoute);
+  
+/** Type override */
+export type OpenAIEnabledRoutes = t.TypeOf<typeof OpenAIEnabledRoutes>;
+
+export const OpenAIIntegration = buildAIIntegrationType<OpenAIRouteNameC, EnabledRoutesC<OpenAIRouteNameC>>({
+  TEnabledRoutes: OpenAIEnabledRoutes,
 });
 
 /** Type override */

--- a/src/codecs.ts
+++ b/src/codecs.ts
@@ -955,13 +955,8 @@ export const OpenAIEnabledRoute = buildEnabledRouteType({
 /** Type override */
 export type OpenAIEnabledRoute = t.TypeOf<typeof OpenAIEnabledRoute>;
 
-export const OpenAIEnabledRoutes = t.array(OpenAIEnabledRoute);
-
-  /** Type override */
-  export type OpenAIEnabledRoutes = t.TypeOf<typeof OpenAIEnabledRoutes>;
-
-export const OpenAIIntegration = buildAIIntegrationType<OpenAIRouteName, OpenAIEnabledRoutes>({
-  TEnabledRoutes: OpenAIEnabledRoutes,
+export const OpenAIIntegration = buildAIIntegrationType<OpenAIRouteName, t.array(OpenAIEnabledRoute)>({
+  TEnabledRoutes:  t.array(OpenAIEnabledRoute),
 });
 
 /** Type override */

--- a/src/codecs.ts
+++ b/src/codecs.ts
@@ -939,13 +939,16 @@ export type AIIntegrationC<T extends t.Mixed> = t.TypeC<{
   enabledRoutes: EnabledRoutesC<T>;
 }>;
 
+/** The codec of OpenAI routeName */
 export type OpenAIRouteNameC = t.LiteralC<'/v1/chat/completions'>
 
 /**
  * The names of the OpenAI routes that we support setting policies for
  * reference: https://platform.openai.com/docs/api-reference/introduction
  */
-export const OpenAIRouteName: OpenAIRouteNameC = t.literal('/v1/chat/completions');
+export const OpenAIRouteName: OpenAIRouteNameC = t.literal(
+  '/v1/chat/completions'
+);
 
 /** Type override */
 export type OpenAIRouteName = t.TypeOf<typeof OpenAIRouteName>;
@@ -957,12 +960,16 @@ export const OpenAIEnabledRoute = buildEnabledRouteType({
 /** Type override */
 export type OpenAIEnabledRoute = t.TypeOf<typeof OpenAIEnabledRoute>;
 
-export const OpenAIEnabledRoutes = t.array(OpenAIEnabledRoute);
+/** The enabled routes for OpenAI */
+export const OpenAIEnabledRoutes: EnabledRoutesC<OpenAIRouteNameC> = t.array(OpenAIEnabledRoute);
   
 /** Type override */
 export type OpenAIEnabledRoutes = t.TypeOf<typeof OpenAIEnabledRoutes>;
 
-export const OpenAIIntegration = buildAIIntegrationType<OpenAIRouteNameC, EnabledRoutesC<OpenAIRouteNameC>>({
+export const OpenAIIntegration = buildAIIntegrationType<
+  OpenAIRouteNameC,
+  EnabledRoutesC<OpenAIRouteNameC>
+>({
   TEnabledRoutes: OpenAIEnabledRoutes,
 });
 

--- a/src/codecs.ts
+++ b/src/codecs.ts
@@ -956,7 +956,7 @@ export const OpenAIEnabledRoute = buildEnabledRouteType({
 export type OpenAIEnabledRoute = t.TypeOf<typeof OpenAIEnabledRoute>;
 
 export const OpenAIIntegration = buildAIIntegrationType<OpenAIRouteName, t.array(OpenAIEnabledRoute)>({
-  TEnabledRoutes:  t.array(OpenAIEnabledRoute),
+  TEnabledRoutes: t.array(OpenAIEnabledRoute),
 });
 
 /** Type override */

--- a/src/codecs.ts
+++ b/src/codecs.ts
@@ -963,7 +963,7 @@ export type OpenAIEnabledRoute = t.TypeOf<typeof OpenAIEnabledRoute>;
 /** The enabled routes for OpenAI */
 export const OpenAIEnabledRoutes: EnabledRoutesC<OpenAIRouteNameC> =
   t.array(OpenAIEnabledRoute);
-  
+
 /** Type override */
 export type OpenAIEnabledRoutes = t.TypeOf<typeof OpenAIEnabledRoutes>;
 

--- a/src/codecs.ts
+++ b/src/codecs.ts
@@ -923,20 +923,20 @@ export type Policy = t.TypeOf<typeof Policy>;
 export type PolicyC = t.UnionC<[t.LiteralC<'redactEmail'>, t.LiteralC<'log'>]>;
 
 /** the codec of a route enabled in an AI integration */
-export type EnabledRouteC = t.TypeC<{
+export type EnabledRouteC<T extends t.Mixed> = t.TypeC<{
   /** the name of the enabled route */
-  routeName: t.Mixed;
+  routeName: T;
   /** the enabled policies */
   enabledPolicies: t.ArrayC<PolicyC>;
 }>;
 
 /** the codec of routes enabled in an AI integration */
-export type EnabledRoutesC = t.ArrayC<EnabledRouteC>;
+export type EnabledRoutesC<T extends t.Mixed> = t.ArrayC<EnabledRouteC<T>>;
 
 /** the codec of an AI Integration */
-export type AIIntegrationC = t.TypeC<{
+export type AIIntegrationC<T extends t.Mixed> = t.TypeC<{
   /** the routes enabled in the AI integration */
-  enabledRoutes: EnabledRoutesC;
+  enabledRoutes: EnabledRoutesC<T>;
 }>;
 
 /**

--- a/src/helpers/buildAIIntegrationType.ts
+++ b/src/helpers/buildAIIntegrationType.ts
@@ -7,12 +7,12 @@ import { AIIntegrationC, EnabledRouteC } from '../codecs';
  * @param TEnabledRoutes - the type of the enabledRoutes for the AIIntegration type
  * @returns an AIIntegration type
  */
-export const buildAIIntegrationType = <T extends t.ArrayC<EnabledRouteC>>({
+export const buildAIIntegrationType = <T extends t.Mixed, P extends t.ArrayC<EnabledRouteC<T>>>({
   TEnabledRoutes,
 }: {
   /** the type of the enabledRoutes property */
-  TEnabledRoutes: T;
-}): AIIntegrationC =>
+  TEnabledRoutes: P;
+}): AIIntegrationC<T> =>
   t.type({
     enabledRoutes: TEnabledRoutes,
   });

--- a/src/helpers/buildEnabledRouteType.ts
+++ b/src/helpers/buildEnabledRouteType.ts
@@ -12,7 +12,7 @@ export const buildEnabledRouteType = <T extends t.Mixed>({
 }: {
   /** the type of the routeName property */
   TRouteName: T;
-}): EnabledRouteC =>
+}): EnabledRouteC<T> =>
   t.type({
     routeName: TRouteName,
     enabledPolicies: t.array(Policy),


### PR DESCRIPTION
- This adds support for a new OpeAI endpoint `v1/embeddings`
- Additionally, it makes it so that if I do

```
const OpenAIEnabledRoute = t.TypeOf<typeof OpenAIEnabledRoute>
```

I'll get back `OpenAIEnabledRoute` equal to

```
{
    routeName: '/v1/chat/completions';
    enabledPolicies: ("redactEmail" | "log")[];
}
```

instead of 


```
{
    routeName: any;
    enabledPolicies: ("redactEmail" | "log")[];
}
```

