### PR TITLE
Add date range filters for all request commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -683,6 +683,8 @@ The API key needs the following scopes:
 | auth             | The Transcend API key with the scopes necessary for the command.                                                                           | string          | N/A                      | true     |
 | actions          | The [request actions](https://docs.transcend.io/docs/privacy-requests/configuring-requests/data-subject-requests#data-actions) to approve. | RequestAction[] | N/A                      | true     |
 | silentModeBefore | Any requests made before this date should be marked as silent mode                                                                         | Date            | N/A                      | false    |
+| createdAtBefore  | Approve requests that were submitted before this time                                                                                      | Date            | N/A                      | false    |
+| createdAtAfter   | Approve requests that were submitted after this time                                                                                       | Date            | N/A                      | false    |
 | transcendUrl     | URL of the Transcend backend. Use https://api.us.transcend.io for US hosting.                                                              | string - URL    | https://api.transcend.io | false    |
 | concurrency      | The concurrency to use when uploading requests in parallel.                                                                                | number          | 100                      | false    |
 
@@ -712,6 +714,12 @@ Increase the concurrency (defaults to 100)
 yarn tr-request-approve --auth=$TRANSCEND_API_KEY --actions=ERASURE --concurrency=500
 ```
 
+Approve ERASURE requests created within a specific time frame
+
+```sh
+yarn tr-request-approve --auth=$TRANSCEND_API_KEY --actions=SALE_OPT_OUT --createdAtBefore=05/03/2023 --createdAtAfter=04/03/2023
+```
+
 ### tr-request-cancel
 
 Bulk cancel a set of privacy requests from the [Privacy Requests -> Incoming Requests](https://app.transcend.io/privacy-requests/incoming-requests) tab.
@@ -727,17 +735,18 @@ The API key needs the following scopes:
 
 #### Arguments
 
-| Argument   | Description                                                                                                                               | Type            | Default                                                                                  | Required |
-| ---------- | ----------------------------------------------------------------------------------------------------------------------------------------- | --------------- | ---------------------------------------------------------------------------------------- | -------- |
-| auth       | The Transcend API key with the scopes necessary for the command.                                                                          | string          | N/A                                                                                      | true     |
-| actions    | The [request actions](https://docs.transcend.io/docs/privacy-requests/configuring-requests/data-subject-requests#data-actions) to cancel. | RequestAction[] | N/A                                                                                      | true     |
-| statuses   | The [request statuses](https://docs.transcend.io/docs/privacy-requests/overview#request-statuses) to cancel.                              | RequestStatus[] | REQUEST_MADE,WAITING,ENRICHING,COMPILING,DELAYED,APPROVING,SECONDARY,SECONDARY_APPROVING | false    |
-| requestIds | Specify the specific request IDs to cancel                                                                                                | string[]        | []                                                                                       | false    |
-
-| silentModeBefore | Any requests made before this date should be marked as silent mode for canceling to skip email sending | Date | N/A | false |
-| cancellationTitle | The title of the [email template](https://app.transcend.io/privacy-requests/email-templates) that should be sent to the requests upon cancelation. Any request in silent mode will not be emailed. | string | Request Canceled | false |
-| transcendUrl | URL of the Transcend backend. Use https://api.us.transcend.io for US hosting. | string - URL | https://api.transcend.io | false |
-| concurrency | The concurrency to use when uploading requests in parallel. | number | 100 | false |
+| Argument          | Description                                                                                                                                                                                        | Type            | Default                                                                                  | Required |
+| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------- | ---------------------------------------------------------------------------------------- | -------- |
+| auth              | The Transcend API key with the scopes necessary for the command.                                                                                                                                   | string          | N/A                                                                                      | true     |
+| actions           | The [request actions](https://docs.transcend.io/docs/privacy-requests/configuring-requests/data-subject-requests#data-actions) to cancel.                                                          | RequestAction[] | N/A                                                                                      | true     |
+| statuses          | The [request statuses](https://docs.transcend.io/docs/privacy-requests/overview#request-statuses) to cancel.                                                                                       | RequestStatus[] | REQUEST_MADE,WAITING,ENRICHING,COMPILING,DELAYED,APPROVING,SECONDARY,SECONDARY_APPROVING | false    |
+| requestIds        | Specify the specific request IDs to cancel                                                                                                                                                         | string[]        | []                                                                                       | false    |
+| silentModeBefore  | Any requests made before this date should be marked as silent mode for canceling to skip email sending                                                                                             | Date            | N/A                                                                                      | false    |
+| createdAtBefore   | Cancel requests that were submitted before this time                                                                                                                                               | Date            | N/A                                                                                      | false    |
+| createdAtAfter    | Cancel requests that were submitted after this time                                                                                                                                                | Date            | N/A                                                                                      | false    |
+| cancellationTitle | The title of the [email template](https://app.transcend.io/privacy-requests/email-templates) that should be sent to the requests upon cancelation. Any request in silent mode will not be emailed. | string          | Request Canceled                                                                         | false    |
+| transcendUrl      | URL of the Transcend backend. Use https://api.us.transcend.io for US hosting.                                                                                                                      | string - URL    | https://api.transcend.io                                                                 | false    |
+| concurrency       | The concurrency to use when uploading requests in parallel.                                                                                                                                        | number          | 100                                                                                      | false    |
 
 #### Usage
 
@@ -778,6 +787,12 @@ Cancel all open SALE_OPT_OUT, but mark any request made before 05/03/2023 as sil
 yarn tr-request-cancel --auth=$TRANSCEND_API_KEY --actions=SALE_OPT_OUT --silentModeBefore=05/03/2023
 ```
 
+Cancel all open SALE_OPT_OUT, within a specific time frame
+
+```sh
+yarn tr-request-cancel --auth=$TRANSCEND_API_KEY --actions=SALE_OPT_OUT --createdAtBefore=05/03/2023 --createdAtAfter=04/03/2023
+```
+
 Increase the concurrency (defaults to 100)
 
 ```sh
@@ -798,16 +813,16 @@ The API key needs the following scopes:
 
 #### Arguments
 
-| Argument   | Description                                                                                                                                    | Type            | Default                                                                                  | Required |
-| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | --------------- | ---------------------------------------------------------------------------------------- | -------- |
-| auth       | The Transcend API key with the scopes necessary for the command.                                                                               | string          | N/A                                                                                      | true     |
-| actions    | The [request actions](https://docs.transcend.io/docs/privacy-requests/configuring-requests/data-subject-requests#data-actions) to mark silent. | RequestAction[] | N/A                                                                                      | true     |
-| statuses   | The [request statuses](https://docs.transcend.io/docs/privacy-requests/overview#request-statuses) to mark silent.                              | RequestStatus[] | REQUEST_MADE,WAITING.ENRICHING,COMPILING,DELAYED,APPROVING,SECONDARY,SECONDARY_APPROVING | false    |
-| requestIds | Specify the specific request IDs to mark silent                                                                                                | string[]        | []                                                                                       | false    |
-
-| silentModeBefore | Any requests made before this date should be marked as silent mode | Date | N/A | false |
-| transcendUrl | URL of the Transcend backend. Use https://api.us.transcend.io for US hosting. | string - URL | https://api.transcend.io | false |
-| concurrency | The concurrency to use when uploading requests in parallel. | number | 100 | false |
+| Argument        | Description                                                                                                                                    | Type            | Default                                                                                  | Required |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | --------------- | ---------------------------------------------------------------------------------------- | -------- |
+| auth            | The Transcend API key with the scopes necessary for the command.                                                                               | string          | N/A                                                                                      | true     |
+| actions         | The [request actions](https://docs.transcend.io/docs/privacy-requests/configuring-requests/data-subject-requests#data-actions) to mark silent. | RequestAction[] | N/A                                                                                      | true     |
+| statuses        | The [request statuses](https://docs.transcend.io/docs/privacy-requests/overview#request-statuses) to mark silent.                              | RequestStatus[] | REQUEST_MADE,WAITING.ENRICHING,COMPILING,DELAYED,APPROVING,SECONDARY,SECONDARY_APPROVING | false    |
+| requestIds      | Specify the specific request IDs to mark silent                                                                                                | string[]        | []                                                                                       | false    |
+| createdAtBefore | Mark silent requests that were submitted before this time                                                                                      | Date            | N/A                                                                                      | false    |
+| createdAtAfter  | Mark silent requests that were submitted after this time                                                                                       | Date            | N/A                                                                                      | false    |
+| transcendUrl    | URL of the Transcend backend. Use https://api.us.transcend.io for US hosting.                                                                  | string - URL    | https://api.transcend.io                                                                 | false    |
+| concurrency     | The concurrency to use when uploading requests in parallel.                                                                                    | number          | 100                                                                                      | false    |
 
 #### Usage
 
@@ -836,10 +851,10 @@ yarn tr-request-mark-silent --auth=$TRANSCEND_API_KEY --actions=ACCESS,ERASURE,S
   --requestIds=c3ae78c9-2768-4666-991a-d2f729503337,342e4bd1-64ea-4af0-a4ad-704b5a07cfe4
 ```
 
-Mark sale opt out requests as silent if those requests were made before a certain date
+Mark sale opt out requests as silent within a certain date range
 
 ```sh
-yarn tr-request-mark-silent --auth=$TRANSCEND_API_KEY --actions=SALE_OPT_OUT --silentModeBefore=05/03/2023
+yarn tr-request-mark-silent --auth=$TRANSCEND_API_KEY --actions=SALE_OPT_OUT --createdAtBefore=05/03/2023 --createdAtAfter=04/03/2023
 ```
 
 Increase the concurrency (defaults to 100)
@@ -1004,7 +1019,9 @@ The API key needs the following scopes:
 | requestIds           | Specify the specific request IDs to restart                                                                                               | string[]        | []                                | false    |
 | emailIsVerified      | Indicate whether the primary email address is verified. Set to false to send a verification email.                                        | boolean         | true                              | false    |
 | createdAt            | Restart requests that were submitted before a specific date.                                                                              | Date            | Date.now()                        | false    |
-| markSilent           | Requests older than this date should be marked as silent mode                                                                             | Date            | Date.now() - 3 months             | false    |
+| silentModeBefore     | Requests older than this date should be marked as silent mode                                                                             | Date            | N/A                               | false    |
+| createdAtBefore      | Restart requests that were submitted before this time                                                                                     | Date            | N/A                               | false    |
+| createdAtAfter       | Restart requests that were submitted after this time                                                                                      | Date            | N/A                               | false    |
 | sendEmailReceipt     | Send email receipts to the restarted requests                                                                                             | boolean         | false                             | false    |
 | copyIdentifiers      | Copy over all enriched identifiers from the initial request. Leave false to restart from scratch with initial identifiers only.           | boolean         | false                             | false    |
 | skipWaitingPeriod    | Skip queued state of request and go straight to compiling                                                                                 | boolean         | false                             | false    |
@@ -1055,7 +1072,13 @@ yarn tr-request-restart --auth=$TRANSCEND_API_KEY --statuses=COMPILING,ENRICHING
 Restart requests and place everything in silent mode submitted before a certain date
 
 ```sh
-yarn tr-request-restart --auth=$TRANSCEND_API_KEY --statuses=COMPILING,ENRICHING --actions=ACCESS,ERASURE --markSilent=2022-12-05T00:46
+yarn tr-request-restart --auth=$TRANSCEND_API_KEY --statuses=COMPILING,ENRICHING --actions=ACCESS,ERASURE --silentModeBefore=2022-12-05T00:46
+```
+
+Restart requests within a specific timeframe
+
+```sh
+yarn tr-request-restart --auth=$TRANSCEND_API_KEY --statuses=COMPILING,ENRICHING --actions=ACCESS,ERASURE ---createdAtBefore="04/05/2023" --createdAtAfter="02/21/2023"
 ```
 
 Send email receipts to the restarted requests
@@ -1345,19 +1368,19 @@ In order to use this cli, you will first need to generate an API key on the Tran
 The API key must have the following scopes:
 
 - "Manage Request Identity Verification"
-- "Manage Request Compilation" (only when specifying `markSilent`)
+- "Manage Request Compilation" (only when specifying `silentModeBefore`)
 
 #### Arguments
 
-| Argument     | Description                                                                          | Type               | Default                             | Required |
-| ------------ | ------------------------------------------------------------------------------------ | ------------------ | ----------------------------------- | -------- |
-| auth         | The Transcend API key with the scopes necessary for the command.                     | string             | N/A                                 | true     |
-| enricherId   | The ID of the Request Enricher to upload to                                          | string - UUID      | N/A                                 | true     |
-| sombraAuth   | The sombra internal key, use for additional authentication when self-hosting sombra. | string             | N/A                                 | false    |
-| transcendUrl | URL of the Transcend backend. Use https://api.us.transcend.io for US hosting.        | string - URL       | https://api.transcend.io            | false    |
-| file         | Path to the CSV file where requests will be written to.                              | string - file-path | ./manual-enrichment-identifiers.csv | false    |
-| markSilent   | When true, set requests into silent mode before enriching                            | boolean            | false                               | false    |
-| concurrency  | The concurrency to use when uploading requests in parallel.                          | number             | 100                                 | false    |
+| Argument         | Description                                                                          | Type               | Default                             | Required |
+| ---------------- | ------------------------------------------------------------------------------------ | ------------------ | ----------------------------------- | -------- |
+| auth             | The Transcend API key with the scopes necessary for the command.                     | string             | N/A                                 | true     |
+| enricherId       | The ID of the Request Enricher to upload to                                          | string - UUID      | N/A                                 | true     |
+| sombraAuth       | The sombra internal key, use for additional authentication when self-hosting sombra. | string             | N/A                                 | false    |
+| transcendUrl     | URL of the Transcend backend. Use https://api.us.transcend.io for US hosting.        | string - URL       | https://api.transcend.io            | false    |
+| file             | Path to the CSV file where requests will be written to.                              | string - file-path | ./manual-enrichment-identifiers.csv | false    |
+| silentModeBefore | When true, set requests into silent mode before enriching                            | boolean            | false                               | false    |
+| concurrency      | The concurrency to use when uploading requests in parallel.                          | number             | 100                                 | false    |
 
 #### Usage
 
@@ -1392,7 +1415,7 @@ yarn tr-manual-enrichment-push-identifiers --auth=$TRANSCEND_API_KEY --enricherI
 When enriching requests, mark all requests as silent mode before processing
 
 ```sh
-yarn tr-manual-enrichment-push-identifiers --auth=$TRANSCEND_API_KEY --enricherId=27d45a0d-7d03-47fa-9b30-6d697005cfcf --markSilent=true
+yarn tr-manual-enrichment-push-identifiers --auth=$TRANSCEND_API_KEY --enricherId=27d45a0d-7d03-47fa-9b30-6d697005cfcf --silentModeBefore=true
 ```
 
 ### tr-mark-request-data-silos-completed

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/cli",
   "description": "Small package containing useful typescript utilities.",
-  "version": "4.88.7",
+  "version": "4.89.0",
   "homepage": "https://github.com/transcend-io/cli",
   "repository": {
     "type": "git",

--- a/src/cli-request-approve.ts
+++ b/src/cli-request-approve.ts
@@ -27,11 +27,20 @@ import { DEFAULT_TRANSCEND_API } from './constants';
 async function main(): Promise<void> {
   // Parse command line arguments
   const {
+    /** Transcend Backend URL */
     transcendUrl = DEFAULT_TRANSCEND_API,
+    /** API key */
     auth,
+    /** Approve these specific actions */
     actions = '',
+    /** Mark as silent mode when made before this date */
     silentModeBefore,
+    /** Concurrency to approve requests at */
     concurrency = '50',
+    /** Filter for requests created before this date */
+    createdAtBefore,
+    /** Filter for requests created after this date */
+    createdAtAfter,
   } = yargs(process.argv.slice(2)) as { [k in string]: string };
 
   // Ensure auth is passed
@@ -67,6 +76,8 @@ async function main(): Promise<void> {
     auth,
     concurrency: parseInt(concurrency, 10),
     silentModeBefore: silentModeBefore ? new Date(silentModeBefore) : undefined,
+    createdAtBefore: createdAtBefore ? new Date(createdAtBefore) : undefined,
+    createdAtAfter: createdAtAfter ? new Date(createdAtAfter) : undefined,
   });
 }
 

--- a/src/cli-request-cancel.ts
+++ b/src/cli-request-cancel.ts
@@ -25,13 +25,24 @@ import { DEFAULT_TRANSCEND_API } from './constants';
 async function main(): Promise<void> {
   // Parse command line arguments
   const {
+    /** Transcend Backend URL */
     transcendUrl = DEFAULT_TRANSCEND_API,
+    /** API key */
     auth,
+    /** Cancel these specific actions */
     actions = '',
+    /** Cancel these specific request statuses */
     statuses = '',
+    /** Mark requests to silent mode when canceling if created before this date */
     silentModeBefore,
+    /** Email template title to sue when canceling requests */
     cancellationTitle,
+    /** Concurrency to cancel requests at */
     concurrency = '50',
+    /** Filter for requests created before this date */
+    createdAtBefore,
+    /** Filter for requests created after this date */
+    createdAtAfter,
     /** List of request IDs */
     requestIds = '',
   } = yargs(process.argv.slice(2)) as { [k in string]: string };
@@ -88,6 +99,8 @@ async function main(): Promise<void> {
     statuses: parsedStatuses.length > 0 ? parsedStatuses : undefined,
     concurrency: parseInt(concurrency, 10),
     silentModeBefore: silentModeBefore ? new Date(silentModeBefore) : undefined,
+    createdAtBefore: createdAtBefore ? new Date(createdAtBefore) : undefined,
+    createdAtAfter: createdAtAfter ? new Date(createdAtAfter) : undefined,
   });
 }
 

--- a/src/cli-request-export.ts
+++ b/src/cli-request-export.ts
@@ -31,13 +31,21 @@ async function main(): Promise<void> {
   // Parse command line arguments
   const {
     file = './transcend-request-export.csv',
+    /** Transcend Backend URL */
     transcendUrl = DEFAULT_TRANSCEND_API,
+    /** API key */
     auth,
+    /** Request actions to export */
     actions = '',
+    /** Request statuses to export */
     statuses = '',
+    /** Whether or not to include test requests */
     showTests,
+    /** Filter on requests created before this date */
     createdAtBefore,
+    /** Filter on requests created after this date */
     createdAtAfter,
+    /** Page limit when paginating */
     pageLimit = '100',
   } = yargs(process.argv.slice(2)) as { [k in string]: string };
 

--- a/src/cli-request-mark-silent.ts
+++ b/src/cli-request-mark-silent.ts
@@ -16,21 +16,29 @@ import { DEFAULT_TRANSCEND_API } from './constants';
  *
  * Dev Usage:
  * yarn ts-node ./src/cli-request-mark-silent.ts --auth=$TRANSCEND_API_KEY \
- *   --actions=ERASURE --silentModeBefore=06/23/2023
+ *   --actions=ERASURE --createdAtBefore=06/23/2023
  *
  * Standard usage:
  * yarn tr-request-mark-silent --auth=$TRANSCEND_API_KEY  \
- *   --actions=ERASURE --silentModeBefore=06/23/2023
+ *   --actions=ERASURE --createdAtBefore=06/23/2023
  */
 async function main(): Promise<void> {
   // Parse command line arguments
   const {
+    /** Transcend Backend URL */
     transcendUrl = DEFAULT_TRANSCEND_API,
+    /** API key */
     auth,
+    /** Mark these specific actions as silent mode */
     actions = '',
+    /** Make these statuses silent mode - defaults to statuses for active requests */
     statuses = '',
-    silentModeBefore,
-    concurrency = '100',
+    /** Concurrency to mark silent */
+    concurrency = '50',
+    /** Filter for requests created before this date */
+    createdAtBefore,
+    /** Filter for requests created after this date */
+    createdAtAfter,
     /** List of request IDs */
     requestIds = '',
   } = yargs(process.argv.slice(2)) as { [k in string]: string };
@@ -85,7 +93,8 @@ async function main(): Promise<void> {
     requestIds: requestIds ? splitCsvToList(requestIds) : undefined,
     statuses: parsedStatuses.length > 0 ? parsedStatuses : undefined,
     concurrency: parseInt(concurrency, 10),
-    silentModeBefore: silentModeBefore ? new Date(silentModeBefore) : undefined,
+    createdAtBefore: createdAtBefore ? new Date(createdAtBefore) : undefined,
+    createdAtAfter: createdAtAfter ? new Date(createdAtAfter) : undefined,
   });
 }
 

--- a/src/cli-request-restart.ts
+++ b/src/cli-request-restart.ts
@@ -8,8 +8,6 @@ import { splitCsvToList, bulkRestartRequests } from './requests';
 import { RequestAction, RequestStatus } from '@transcend-io/privacy-types';
 import { DEFAULT_TRANSCEND_API } from './constants';
 
-const ONE_MONTH = 30.5 * 24 * 60 * 60 * 1000;
-
 /**
  * Run a command to bulk restart a set of privacy requests
  *
@@ -28,8 +26,11 @@ const ONE_MONTH = 30.5 * 24 * 60 * 60 * 1000;
 async function main(): Promise<void> {
   // Parse command line arguments
   const {
-    auth,
+    /** Transcend Backend URL */
     transcendUrl = DEFAULT_TRANSCEND_API,
+    /** API key */
+    auth,
+    /** Sombra API key */
     sombraAuth,
     /** Restart requests matching these request actions */
     actions,
@@ -42,7 +43,7 @@ async function main(): Promise<void> {
     /** Filter for requests that were submitted before this date */
     createdAt = new Date().toISOString(),
     /** Requests that have been open for this length of time should be marked as silent mode */
-    markSilent = new Date(+new Date() - ONE_MONTH * 3).toISOString(),
+    silentModeBefore,
     /** Send an email receipt to the restarted requests */
     sendEmailReceipt = 'false',
     /** Copy over all identifiers rather than restarting the request only with the core identifier */
@@ -53,6 +54,10 @@ async function main(): Promise<void> {
     skipWaitingPeriod = 'false',
     /** Include a receipt of the requests that were restarted in this file */
     requestReceiptFolder = './privacy-request-upload-receipts',
+    /** Filter for requests created before this date */
+    createdAtBefore,
+    /** Filter for requests created after this date */
+    createdAtAfter,
   } = yargs(process.argv.slice(2)) as { [k in string]: string };
 
   // Ensure auth is passed
@@ -119,10 +124,12 @@ async function main(): Promise<void> {
     requestIds: splitCsvToList(requestIds),
     createdAt: new Date(createdAt),
     emailIsVerified: emailIsVerified === 'true',
-    markSilent: new Date(markSilent),
+    silentModeBefore: silentModeBefore ? new Date(silentModeBefore) : undefined,
     sendEmailReceipt: sendEmailReceipt === 'true',
     copyIdentifiers: copyIdentifiers === 'true',
     skipWaitingPeriod: skipWaitingPeriod === 'true',
+    createdAtBefore: createdAtBefore ? new Date(createdAtBefore) : undefined,
+    createdAtAfter: createdAtAfter ? new Date(createdAtAfter) : undefined,
     concurrency: parseInt(concurrency, 10),
     transcendUrl,
   });

--- a/src/requests/approvePrivacyRequests.ts
+++ b/src/requests/approvePrivacyRequests.ts
@@ -22,6 +22,8 @@ export async function approvePrivacyRequests({
   requestActions,
   auth,
   silentModeBefore,
+  createdAtAfter,
+  createdAtBefore,
   concurrency = 50,
   transcendUrl = DEFAULT_TRANSCEND_API,
 }: {
@@ -33,6 +35,10 @@ export async function approvePrivacyRequests({
   concurrency?: number;
   /** Mark these requests as silent mode if they were created before this date */
   silentModeBefore?: Date;
+  /** Filter for requests created before this date */
+  createdAtBefore?: Date;
+  /** Filter for requests created after this date */
+  createdAtAfter?: Date;
   /** API URL for Transcend backend */
   transcendUrl?: string;
 }): Promise<number> {
@@ -51,6 +57,8 @@ export async function approvePrivacyRequests({
   const allRequests = await fetchAllRequests(client, {
     actions: requestActions,
     statuses: [RequestStatus.Approving],
+    createdAtAfter,
+    createdAtBefore,
   });
 
   // Notify Transcend

--- a/src/requests/bulkRestartRequests.ts
+++ b/src/requests/bulkRestartRequests.ts
@@ -46,10 +46,12 @@ export async function bulkRestartRequests({
   sombraAuth,
   requestActions,
   requestStatuses,
+  createdAtBefore,
+  createdAtAfter,
   transcendUrl = DEFAULT_TRANSCEND_API,
   requestIds = [],
   createdAt = new Date(),
-  markSilent,
+  silentModeBefore,
   sendEmailReceipt = false,
   emailIsVerified = true,
   copyIdentifiers = false,
@@ -75,13 +77,17 @@ export async function bulkRestartRequests({
   /** Filter for requests that were submitted before this date */
   createdAt?: Date;
   /** Requests that have been open for this length of time should be marked as silent mode */
-  markSilent?: Date;
+  silentModeBefore?: Date;
   /** Send an email receipt to the restarted requests */
   sendEmailReceipt?: boolean;
   /** Copy over all identifiers rather than restarting the request only with the core identifier */
   copyIdentifiers?: boolean;
   /** Skip the waiting period when restarting requests */
   skipWaitingPeriod?: boolean;
+  /** Filter for requests created before this date */
+  createdAtBefore?: Date;
+  /** Filter for requests created after this date */
+  createdAtAfter?: Date;
   /** Concurrency to upload requests at */
   concurrency?: number;
 }): Promise<void> {
@@ -114,6 +120,8 @@ export async function bulkRestartRequests({
   const allRequests = await fetchAllRequests(client, {
     actions: requestActions,
     statuses: requestStatuses,
+    createdAtBefore,
+    createdAtAfter,
   });
   const requests = allRequests.filter(
     (request) =>
@@ -171,7 +179,8 @@ export async function bulkRestartRequests({
             ...request,
             // override silent mode
             isSilent:
-              !!markSilent && new Date(request.createdAt) < markSilent
+              !!silentModeBefore &&
+              new Date(request.createdAt) < silentModeBefore
                 ? true
                 : request.isSilent,
           },

--- a/src/requests/cancelPrivacyRequests.ts
+++ b/src/requests/cancelPrivacyRequests.ts
@@ -26,6 +26,8 @@ export async function cancelPrivacyRequests({
   auth,
   requestIds,
   silentModeBefore,
+  createdAtBefore,
+  createdAtAfter,
   statuses = [
     RequestStatus.Compiling,
     RequestStatus.RequestMade,
@@ -51,6 +53,10 @@ export async function cancelPrivacyRequests({
   requestIds?: string[];
   /** Mark these requests as silent mode if they were created before this date */
   silentModeBefore?: Date;
+  /** Filter for requests created before this date */
+  createdAtBefore?: Date;
+  /** Filter for requests created after this date */
+  createdAtAfter?: Date;
   /** API URL for Transcend backend */
   transcendUrl?: string;
   /** The email template to use when canceling the requests */
@@ -88,6 +94,8 @@ export async function cancelPrivacyRequests({
   // Pull in the requests
   let allRequests = await fetchAllRequests(client, {
     actions: requestActions,
+    createdAtBefore,
+    createdAtAfter,
     statuses,
   });
 

--- a/src/requests/markSilentPrivacyRequests.ts
+++ b/src/requests/markSilentPrivacyRequests.ts
@@ -21,7 +21,6 @@ export async function markSilentPrivacyRequests({
   requestActions,
   auth,
   requestIds,
-  silentModeBefore,
   statuses = [
     RequestStatus.Compiling,
     RequestStatus.RequestMade,
@@ -32,6 +31,8 @@ export async function markSilentPrivacyRequests({
     RequestStatus.Waiting,
     RequestStatus.SecondaryApproving,
   ],
+  createdAtAfter,
+  createdAtBefore,
   concurrency = 100,
   transcendUrl = DEFAULT_TRANSCEND_API,
 }: {
@@ -45,8 +46,10 @@ export async function markSilentPrivacyRequests({
   statuses?: RequestStatus[];
   /** The set of privacy requests to cancel */
   requestIds?: string[];
-  /** Mark these requests as silent mode if they were created before this date */
-  silentModeBefore?: Date;
+  /** Filter for requests created before this date */
+  createdAtBefore?: Date;
+  /** Filter for requests created after this date */
+  createdAtAfter?: Date;
   /** API URL for Transcend backend */
   transcendUrl?: string;
 }): Promise<number> {
@@ -65,7 +68,8 @@ export async function markSilentPrivacyRequests({
   let allRequests = await fetchAllRequests(client, {
     actions: requestActions,
     statuses,
-    createdAtBefore: silentModeBefore,
+    createdAtBefore,
+    createdAtAfter,
   });
 
   // Filter down requests by request ID


### PR DESCRIPTION
All request commands now can filter on specific date ranges when approving, canceling, marking requests as silent