### PR TITLE
TranscendAiPrompt throws error if prompt is rejected, includes template for currentDate

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/cli",
   "description": "Small package containing useful typescript utilities.",
-  "version": "4.96.0",
+  "version": "4.97.0",
   "homepage": "https://github.com/transcend-io/cli",
   "repository": {
     "type": "git",

--- a/src/ai/TranscendAiPrompt.ts
+++ b/src/ai/TranscendAiPrompt.ts
@@ -99,6 +99,13 @@ export class TranscendAiPrompt<
       );
     }
 
+    // If assessment is rejected, throw error
+    if (assessment.status === AssessmentStatus.Rejected) {
+      throw new Error(
+        `Assessment "${this.title}" cannot be used because it's in status: "${assessment.status}"`,
+      );
+    }
+
     // Template attributes into the template string
     const extraParams: ObjByString = {};
     if (fillTemplateWithAttributes) {
@@ -139,6 +146,8 @@ export class TranscendAiPrompt<
     // and provided parameters
     return (params) =>
       this.handlebars.compile(assessment.content)({
+        // template in currentDate by default
+        currentDate: new Date().toISOString(),
         ...extraParams,
         ...params,
       });


### PR DESCRIPTION
- {{{ currentDate }} can now be added into templates
- if an assessment is in a rejected state, the `fetchPromptFromTranscend` function throws an error