### PR TITLE
Pull consent preferences from managed consent database

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/cli",
   "description": "Small package containing useful typescript utilities.",
-  "version": "4.102.0",
+  "version": "4.103.0",
   "homepage": "https://github.com/transcend-io/cli",
   "repository": {
     "type": "git",
@@ -26,6 +26,7 @@
     "tr-mark-request-data-silos-completed": "./build/cli-mark-request-data-silos-completed.js",
     "tr-pull": "./build/cli-pull.js",
     "tr-pull-consent-metrics": "./build/cli-pull-consent-metrics.js",
+    "tr-pull-consent-preferences": "./build/cli-pull-consent-preferences.js",
     "tr-push": "./build/cli-push.js",
     "tr-request-approve": "./build/cli-request-approve.js",
     "tr-request-cancel": "./build/cli-request-cancel.js",

--- a/src/cli-pull-consent-preferences.ts
+++ b/src/cli-pull-consent-preferences.ts
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+
+import yargs from 'yargs-parser';
+import colors from 'colors';
+
+import { logger } from './logger';
+import { DEFAULT_TRANSCEND_API } from './constants';
+import { fetchConsentPreferences } from './consent-manager';
+import { writeCsv } from './cron';
+import { createSombraGotInstance } from './graphql';
+import { splitCsvToList } from './requests';
+
+/**
+ * Pull consent preferences from the managed consent database
+ *
+ * Requires following documentation found at:
+ * https://docs.transcend.io/docs/consent/reference/managed-consent-database
+ * https://docs.transcend.io/docs/api-reference/POST/v1/consent-preferences
+ *
+ * Dev Usage:
+ * yarn ts-node ./src/cli-pull-consent-preferences.ts --auth=$TRANSCEND_API_KEY
+ *
+ * Standard usage:
+ * yarn tr-pull-consent-preferences --auth=$TRANSCEND_API_KEY
+ */
+async function main(): Promise<void> {
+  // Parse command line arguments
+  const {
+    /** File to save preferences to */
+    file = 'preferences.csv',
+    /** Sombra API key */
+    sombraAuth,
+    /** Transcend URL */
+    transcendUrl = DEFAULT_TRANSCEND_API,
+    /** API key */
+    auth,
+    /** Partition key */
+    partition,
+    /** Filter on specific identifiers */
+    identifiers = '',
+    /** Filter on consent preferences changed before this date */
+    timestampBefore,
+    /** Filter on consent preferences changed after this date */
+    timestampAfter,
+    /** Concurrency */
+    concurrency = '100',
+  } = yargs(process.argv.slice(2)) as { [k in string]: string };
+
+  // Ensure auth is passed
+  if (!auth) {
+    logger.error(
+      colors.red(
+        'A Transcend API key must be provided. You can specify using --auth=$TRANSCEND_API_KEY',
+      ),
+    );
+    process.exit(1);
+  }
+
+  // Ensure partition
+  if (!partition) {
+    logger.error(
+      colors.red(
+        'A partition must be provided. ' +
+          'You can specify using --partition=ee1a0845-694e-4820-9d51-50c7d0a23467',
+      ),
+    );
+    process.exit(1);
+  }
+
+  // Create sombra instance to communicate with
+  const sombra = await createSombraGotInstance(transcendUrl, auth, sombraAuth);
+
+  // Fetch preferences
+  const identifiersAsList = splitCsvToList(identifiers);
+  const preferences = await fetchConsentPreferences(sombra, {
+    partition,
+    filterBy: {
+      ...(timestampBefore ? { timestampBefore } : {}),
+      ...(timestampAfter ? { timestampAfter } : {}),
+      ...(identifiersAsList.length > 0
+        ? { identifiers: identifiersAsList }
+        : {}),
+    },
+    limit: parseInt(concurrency, 10),
+  });
+
+  // Write to disk
+  writeCsv(
+    file,
+    preferences.map((pref) => ({
+      ...pref,
+      purposes: JSON.stringify(pref.purposes),
+      ...pref.purposes,
+    })),
+  );
+}
+
+main();

--- a/src/consent-manager/fetchConsentPreferences.ts
+++ b/src/consent-manager/fetchConsentPreferences.ts
@@ -1,0 +1,94 @@
+import * as t from 'io-ts';
+import { decodeCodec } from '@transcend-io/type-utils';
+import type { Got } from 'got';
+
+export const ConsentPreference = t.type({
+  userId: t.string,
+  partition: t.string,
+  timestamp: t.string,
+  purposes: t.record(t.string, t.boolean),
+});
+
+/** Type override */
+export type ConsentPreference = t.TypeOf<typeof ConsentPreference>;
+
+export const ConsentPreferenceResponse = t.intersection([
+  t.type({
+    nodes: t.array(ConsentPreference),
+  }),
+  t.partial({
+    lastKey: t.partial({
+      userId: t.string,
+      partition: t.string,
+    }),
+  }),
+]);
+
+/** Type override */
+export type ConsentPreferenceResponse = t.TypeOf<
+  typeof ConsentPreferenceResponse
+>;
+
+/**
+ * Fetch consent preferences for the managed consent database
+ *
+ * @param sombra - Sombra instance configured to make requests
+ * @param options - Additional options
+ * @returns The consent preferences
+ */
+export async function fetchConsentPreferences(
+  sombra: Got,
+  {
+    partition,
+    filterBy = {},
+    limit = 50,
+  }: {
+    /** Partition key to fetch */
+    partition: string;
+    /** Filter consent preferences */
+    filterBy?: {
+      /** Fetch specific identifiers */
+      identifiers?: string[];
+      /** Filter before timestamp */
+      timestampBefore?: string;
+      /** Filter after timestamp */
+      timestampAfter?: string;
+    };
+    /** Number of items to pull back at once */
+    limit?: number;
+  },
+): Promise<ConsentPreference[]> {
+  let currentLastKey: ConsentPreferenceResponse['lastKey'];
+  const data: ConsentPreference[] = [];
+  let shouldContinue = true;
+
+  while (shouldContinue) {
+    // eslint-disable-next-line no-await-in-loop
+    const response = await sombra
+      .post('v1/consent-preferences', {
+        json: {
+          partition,
+          ...(Object.values(filterBy).length > 0 ? { filterBy } : {}),
+          // using lastKey to paginate if it exists (will not for first iteration)
+          startKey: currentLastKey || undefined,
+          limit,
+        },
+      })
+      .json();
+    const { nodes, lastKey } = decodeCodec(ConsentPreferenceResponse, response);
+
+    if (!nodes || nodes.length === 0) {
+      break;
+    }
+
+    // Process the data received from the API call
+    // For example, push the new data into an array
+    data.push(...nodes);
+
+    // Extract the lastKey from the API response
+    currentLastKey = lastKey;
+    shouldContinue = !!lastKey && Object.keys(lastKey).length > 0;
+  }
+
+  return data;
+}

--- a/src/consent-manager/index.ts
+++ b/src/consent-manager/index.ts
@@ -6,3 +6,4 @@ export * from './buildXdiSyncEndpoint';
 export * from './consentManagersToBusinessEntities';
 export * from './domainToHost';
 export * from './createConsentToken';
+export * from './fetchConsentPreferences';

--- a/yarn.lock
+++ b/yarn.lock
@@ -483,6 +483,7 @@ __metadata:
     tr-mark-request-data-silos-completed: ./build/cli-mark-request-data-silos-completed.js
     tr-pull: ./build/cli-pull.js
     tr-pull-consent-metrics: ./build/cli-pull-consent-metrics.js
+    tr-pull-consent-preferences: ./build/cli-pull-consent-preferences.js
     tr-push: ./build/cli-push.js
     tr-request-approve: ./build/cli-request-approve.js
     tr-request-cancel: ./build/cli-request-cancel.js


### PR DESCRIPTION
This command allows for pull of consent preferences from the [Managed Consent Database](https://docs.transcend.io/docs/api-reference/POST/v1/consent-preferences).

Each row in the CSV will include:

| Argument       | Description                                                                                               | Type                      | Default | Required |
| -------------- | --------------------------------------------------------------------------------------------------------- | ------------------------- | ------- | -------- |
| userId         | Unique ID identifying the user that the preferences ar efor                                               | string                    | N/A     | true     |
| timestamp      | Timestamp for when consent was collected for that user                                                    | string - timestamp        | N/A     | true     |
| purposes       | JSON map from consent purpose name -> boolean indicating whether user has opted in or out of that purpose | {[k in string]: boolean } | {}      | true     |
| usp            | US Privacy string                                                                                         | string - USP              | N/A     | false    |
| airgapVersion  | Version of airgap where consent was collected                                                             | string                    | N/A     | false    |
| [purpose name] | Each consent purpose from `purposes` is also included in a column                                         | boolean                   | N/A     | false    |

#### Authentication

In order to use this cli, you will first need to generate an API key on the Transcend Admin Dashboard (https://app.transcend.io/infrastructure/api-keys).

The API key must have the following scopes:

- "View Managed Consent Database Admin API"

#### Arguments

| Argument        | Description                                                                          | Type               | Default                  | Required |
| --------------- | ------------------------------------------------------------------------------------ | ------------------ | ------------------------ | -------- |
| auth            | The Transcend API key with the scopes necessary for the command.                     | string             | N/A                      | true     |
| partition       | The partition key to upload consent preferences to                                   | string             | N/A                      | true     |
| sombraAuth      | The sombra internal key, use for additional authentication when self-hosting sombra. | string             | N/A                      | false    |
| file            | Path to the CSV file to save preferences to                                          | string - file-path | ./preferences.csv        | false    |
| transcendUrl    | URL of the Transcend backend. Use https://api.us.transcend.io for US hosting.        | string - URL       | https://api.transcend.io | false    |
| timestampBefore | Filter for consents updated this time                                                | Date               | N/A                      | false    |
| timestampAfter  | Filter for consents updated after this time                                          | Date               | N/A                      | false    |
| identifiers     | Filter for specific identifiers                                                      | string[]           | N/A                      | false    |
| concurrency     | The concurrency to use when downloading consents in parallel.                        | number             | 100                      | false    |

#### Usage

Fetch all consent preferences from partition key `4d1c5daa-90b7-4d18-aa40-f86a43d2c726`

```sh
yarn tr-pull-consent-preferences --auth=$TRANSCEND_API_KEY --partition=4d1c5daa-90b7-4d18-aa40-f86a43d2c726
```

Fetch all consent preferences from partition key `4d1c5daa-90b7-4d18-aa40-f86a43d2c726` and save to ./consent.csv

```sh
yarn tr-pull-consent-preferences --auth=$TRANSCEND_API_KEY --partition=4d1c5daa-90b7-4d18-aa40-f86a43d2c726 --file=./consent.csv
```

Filter on consent updates before a date

```sh
yarn tr-pull-consent-preferences --auth=$TRANSCEND_API_KEY --partition=4d1c5daa-90b7-4d18-aa40-f86a43d2c726 --timestampBefore=04/03/2023
```

Filter on consent updates after a date

```sh
yarn tr-pull-consent-preferences --auth=$TRANSCEND_API_KEY --partition=4d1c5daa-90b7-4d18-aa40-f86a43d2c726 --timestampAfter=04/03/2023
```

For self-hosted sombras that use an internal key:

```sh
yarn tr-pull-consent-preferences --auth=$TRANSCEND_API_KEY --sombraAuth=$SOMBRA_INTERNAL_KEY --partition=4d1c5daa-90b7-4d18-aa40-f86a43d2c726
```

Specifying the backend URL, needed for US hosted backend infrastructure.

```sh
yarn tr-pull-consent-preferences --auth=$TRANSCEND_API_KEY --partition=4d1c5daa-90b7-4d18-aa40-f86a43d2c726 --transcendUrl=https://api.us.transcend.io
```
