### PR TITLE
Fix codescan for https: urls

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/cli",
   "description": "Small package containing useful typescript utilities.",
-  "version": "4.130.0",
+  "version": "4.130.1",
   "homepage": "https://github.com/transcend-io/cli",
   "repository": {
     "type": "git",

--- a/src/cli-scan-packages.ts
+++ b/src/cli-scan-packages.ts
@@ -55,7 +55,9 @@ async function main(): Promise<void> {
       );
       // Trim and parse the URL
       const url = name.toString('utf-8').trim();
-      [gitRepositoryName] = (url.split(':').pop() || '').split('.');
+      [gitRepositoryName] = !url.includes('https:')
+        ? (url.split(':').pop() || '').split('.')
+        : url.split('/').slice(3).join('/').split('.');
       if (!gitRepositoryName) {
         logger.error(colors.red(REPO_ERROR));
         process.exit(1);


### PR DESCRIPTION
## Related Issues

- repos with remote urls that start with https:// don't work as expected.
- current code works perfect, if remote origin url is` git@github.com/xyz/abc.git `

## Security Implications

_[none]_

## System Availability

_[none]_
