### PR TITLE
Sync Repositories before syncing code packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/cli",
   "description": "Small package containing useful typescript utilities.",
-  "version": "4.130.1",
+  "version": "4.130.2",
   "homepage": "https://github.com/transcend-io/cli",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/cli",
   "description": "Small package containing useful typescript utilities.",
-  "version": "4.130.0",
+  "version": "4.130.1",
   "homepage": "https://github.com/transcend-io/cli",
   "repository": {
     "type": "git",

--- a/src/cli-scan-packages.ts
+++ b/src/cli-scan-packages.ts
@@ -55,7 +55,9 @@ async function main(): Promise<void> {
       );
       // Trim and parse the URL
       const url = name.toString('utf-8').trim();
-      [gitRepositoryName] = (url.split(':').pop() || '').split('.');
+      [gitRepositoryName] = !url.includes('https:')
+        ? (url.split(':').pop() || '').split('.')
+        : url.split('/').slice(3).join('/').split('.');
       if (!gitRepositoryName) {
         logger.error(colors.red(REPO_ERROR));
         process.exit(1);

--- a/src/graphql/syncCodePackages.ts
+++ b/src/graphql/syncCodePackages.ts
@@ -8,10 +8,11 @@ import { CodePackage, fetchAllCodePackages } from './fetchAllCodePackages';
 import { logger } from '../logger';
 import { syncSoftwareDevelopmentKits } from './syncSoftwareDevelopmentKits';
 import { map, mapSeries } from 'bluebird';
-import { CodePackageInput } from '../codecs';
+import { CodePackageInput, RepositoryInput } from '../codecs';
 import { CodePackageType } from '@transcend-io/privacy-types';
 import { makeGraphQLRequest } from './makeGraphQLRequest';
 import { CREATE_CODE_PACKAGE, UPDATE_CODE_PACKAGES } from './gqls';
+import { syncRepositories } from './syncRepositories';
 
 const CHUNK_SIZE = 100;
 
@@ -158,6 +159,17 @@ export async function syncCodePackages(
           `${name}${LOOKUP_SPLIT_KEY}${codePackageType}`,
       ),
       concurrency,
+    ),
+    // make sure all Repositories exist
+    syncRepositories(
+      client,
+      uniqBy(codePackages, 'repositoryName').map(
+        ({ repositoryName }) =>
+          ({
+            name: repositoryName,
+            url: `https://github.com/${repositoryName}`,
+          } as RepositoryInput),
+      ),
     ),
   ]);
 


### PR DESCRIPTION
## Related Issues

- Sync code packages creates new code packages found in the scan which internally tries to create a repository.
- Ideally the backend has a check to fetch repositoryId by name (but due to concurrency this check is bypassed).
- So scenarios where multiple code packages belong to same repository, we call createCodePackage -> createRepository(multiple times)
- causing
`Client error: Validation error [{"message":"organizationId must be unique","type":"unique violation","path":"organizationId","value":"e1934ef2-05b0-48cb-8837-88de1e2059ad","origin":"DB","validatorKey":"not_unique","validatorName":null,"validatorArgs":[]},{"message":"name must be unique","type":"unique violation","path":"name","value":"transcend-io/consent-manager-android-library","origin":"DB","validatorKey":"not_unique","validatorName":null,"validatorArgs":[]}]`


## Security Implications

_[none]_

## System Availability

_[none]_
