### PR TITLE
Adds progress bars to the `tr-cron-pull-identifiers` and `tr-cron-mark-identifiers-completed` commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/cli",
   "description": "Small package containing useful typescript utilities.",
-  "version": "4.130.5",
+  "version": "4.131.0",
   "homepage": "https://github.com/transcend-io/cli",
   "repository": {
     "type": "git",

--- a/src/cron/markCronIdentifierCompleted.ts
+++ b/src/cron/markCronIdentifierCompleted.ts
@@ -18,12 +18,12 @@ export type CronIdentifierPush = t.TypeOf<typeof CronIdentifierPush>;
  * @see https://docs.transcend.io/docs/api-reference/PUT/v1/data-silo
  * @param sombra - Sombra instance configured to make requests
  * @param options - Additional options
- * @returns Successfully submitted request
+ * @returns Successfully submitted request, false if not in a state to update
  */
 export async function markCronIdentifierCompleted(
   sombra: Got,
   { nonce, identifier }: CronIdentifierPush,
-): Promise<void> {
+): Promise<boolean> {
   try {
     // Make the GraphQL request
     await sombra.put('v1/data-silo', {
@@ -38,10 +38,11 @@ export async function markCronIdentifierCompleted(
         ],
       },
     });
+    return true;
   } catch (err) {
     // handle gracefully
-    if (err.statusCode === 409) {
-      return;
+    if (err.response?.statusCode === 409) {
+      return false;
     }
     throw new Error(
       `Received an error from server: ${err?.response?.body || err?.message}`,

--- a/src/graphql/fetchRequestDataSiloActiveCount.ts
+++ b/src/graphql/fetchRequestDataSiloActiveCount.ts
@@ -1,0 +1,37 @@
+import { GraphQLClient } from 'graphql-request';
+import { REDUCED_REQUESTS_FOR_DATA_SILO_COUNT } from './gqls';
+import { makeGraphQLRequest } from './makeGraphQLRequest';
+
+/**
+ * Get number of open requests for a data silo
+ *
+ * @param client - GraphQL client
+ * @param options - Filter options
+ * @returns List of request identifiers
+ */
+export async function fetchRequestDataSiloActiveCount(
+  client: GraphQLClient,
+  {
+    dataSiloId,
+  }: {
+    /** Data silo ID */
+    dataSiloId: string;
+  },
+): Promise<number> {
+  const {
+    listReducedRequestsForDataSilo: { totalCount },
+  } = await makeGraphQLRequest<{
+    /** Requests */
+    listReducedRequestsForDataSilo: {
+      /** Total count */
+      totalCount: number;
+    };
+  }>(client, REDUCED_REQUESTS_FOR_DATA_SILO_COUNT, {
+    input: {
+      dataSiloId,
+      isResolved: false,
+    },
+  });
+
+  return totalCount;
+}

--- a/src/graphql/gqls/RequestDataSilo.ts
+++ b/src/graphql/gqls/RequestDataSilo.ts
@@ -50,3 +50,20 @@ export const RETRY_REQUEST_DATA_SILO = gql`
     }
   }
 `;
+
+// TODO: https://transcend.height.app/T-27909 - enable optimizations
+// isExportCsv: true
+// useMaster: false
+// orderBy: [
+//   { field: createdAt, direction: DESC }
+//   { field: title, direction: ASC, model: dataSilo }
+// ]
+export const REDUCED_REQUESTS_FOR_DATA_SILO_COUNT = gql`
+  query TranscendCliListReducedRequestsForDataSiloCount(
+    $input: BulkCompletionReducedRequestInput!
+  ) {
+    listReducedRequestsForDataSilo(input: $input) {
+      totalCount
+    }
+  }
+`;

--- a/src/graphql/index.ts
+++ b/src/graphql/index.ts
@@ -18,6 +18,7 @@ export * from './setResourceAttributes';
 export * from './buildTranscendGraphQLClient';
 export * from './gqls';
 export * from './fetchPromptThreads';
+export * from './fetchRequestDataSiloActiveCount';
 export * from './fetchAllAttributeKeys';
 export * from './fetchAllRequests';
 export * from './fetchAllRequestIdentifiers';


### PR DESCRIPTION
- `tr-cron-pull-identifiers` now shows progress bar
- `tr-cron-mark-identifiers-completed` now shows progress bar
- `tr-cron-mark-identifiers-completed` gracefully handles 409 error (Which means the request was already marked as completed