### PR TITLE
Adds ability to push and pull consent partitions

### DIFF
--- a/examples/consent-manager-domains.yml
+++ b/examples/consent-manager-domains.yml
@@ -10,6 +10,11 @@ consent-manager:
     - localhost:3000
     - localhost:8084
   consentPrecedence: user
+  partitions:
+    - name: Staging
+      partition: 1dd7cfef9578d0375c8eec63f364ef72c5429f4e6b732cff8ace1e65b23320a2
+    - name: Dev
+      partition: 3ead9290e548883c3f6e3b5899957290a6468310fb1998373bb62230a1c19a0f
   unknownRequestPolicy: BLOCK
   unknownCookiePolicy: ALLOW
   syncEndpoint: >-

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/cli",
   "description": "Small package containing useful typescript utilities.",
-  "version": "5.1.1",
+  "version": "5.2.0",
   "homepage": "https://github.com/transcend-io/cli",
   "repository": {
     "type": "git",

--- a/src/codecs.ts
+++ b/src/codecs.ts
@@ -793,6 +793,19 @@ export const BusinessEntityInput = t.intersection([
      * Attribute value and its corresponding attribute key
      */
     attributes: t.array(AttributePreview),
+    /**
+     * The email addresses of the employees within your company that are the go-to individuals
+     * for managing this data silo
+     */
+    owners: t.array(t.string),
+    /**
+     * The names of teams within your Transcend instance that should be responsible
+     * for managing this data silo.
+     *
+     * @see https://docs.transcend.io/docs/security/access-control#teams
+     * for more information about how to create and manage teams
+     */
+    teams: t.array(t.string),
   }),
 ]);
 

--- a/src/codecs.ts
+++ b/src/codecs.ts
@@ -1146,6 +1146,20 @@ export type ConsentManageExperienceInput = t.TypeOf<
   typeof ConsentManageExperienceInput
 >;
 
+export const ConsentPartition = t.intersection([
+  t.type({
+    /** Name of partition */
+    name: t.string,
+  }),
+  t.partial({
+    /** Value of partition, cannot be pushed, can only be pulled */
+    partition: t.string,
+  }),
+]);
+
+/** Type override */
+export type ConsentPartition = t.TypeOf<typeof ConsentPartition>;
+
 export const ConsentManagerInput = t.partial({
   /** Airgap version */
   version: t.string,
@@ -1153,6 +1167,8 @@ export const ConsentManagerInput = t.partial({
   bundleUrls: t.record(valuesOf(ConsentBundleType), t.string),
   /** The consent manager domains in the instance */
   domains: t.array(t.string),
+  /** The full list of consent manager partitions (e.g. dev vs staging vs prod) */
+  partitions: t.array(ConsentPartition),
   /** Key used to partition consent records */
   partition: t.string,
   /** Precedence of signals vs user input */

--- a/src/graphql/fetchConsentManagerId.ts
+++ b/src/graphql/fetchConsentManagerId.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import { GraphQLClient } from 'graphql-request';
 import {
   ConsentPrecedenceOption,
@@ -20,10 +21,12 @@ import {
   FETCH_CONSENT_MANAGER,
   EXPERIENCES,
   PURPOSES,
+  CONSENT_PARTITIONS,
   CONSENT_MANAGER_ANALYTICS_DATA,
   FETCH_CONSENT_MANAGER_THEME,
 } from './gqls';
 import { makeGraphQLRequest } from './makeGraphQLRequest';
+import { ConsentPartition } from '../codecs';
 
 export interface ConsentManager {
   /** ID of consent manager */
@@ -315,3 +318,40 @@ export async function fetchConsentManagerTheme(
   });
   return theme;
 }
+
+/**
+ * Fetch the list of consent manager partitions
+ *
+ * @param client - GraphQL client
+ * @returns Consent manager ID in organization
+ */
+export async function fetchConsentManagerPartitions(
+  client: GraphQLClient,
+): Promise<ConsentPartition[]> {
+  const partitions: ConsentPartition[] = [];
+  let offset = 0;
+
+  // Fetch all partitions
+  let shouldContinue = false;
+  do {
+    const {
+      consentPartitions: { nodes },
+      // eslint-disable-next-line no-await-in-loop
+    } = await makeGraphQLRequest<{
+      /** Consent experience */
+      consentPartitions: {
+        /** List */
+        nodes: ConsentPartition[];
+      };
+    }>(client, CONSENT_PARTITIONS, {
+      first: PAGE_SIZE,
+      offset,
+    });
+    partitions.push(...nodes);
+    offset += PAGE_SIZE;
+    shouldContinue = nodes.length === PAGE_SIZE;
+  } while (shouldContinue);
+
+  return partitions.sort((a, b) => a.name.localeCompare(b.name));
+}
+/* eslint-enable max-lines */

--- a/src/graphql/gqls/consentManager.ts
+++ b/src/graphql/gqls/consentManager.ts
@@ -44,6 +44,22 @@ export const EXPERIENCES = gql`
   }
 `;
 
+// TODO: https://transcend.height.app/T-27909 - order by createdAt
+// TODO: https://transcend.height.app/T-27909 - enable optimizations
+// useMaster: false
+// isExportCsv: true
+export const CONSENT_PARTITIONS = gql`
+  query TranscendCliConsentPartitions($first: Int!, $offset: Int!) {
+    consentPartitions(first: $first, offset: $offset) {
+      nodes {
+        id
+        name
+        partition
+      }
+    }
+  }
+`;
+
 export const CREATE_DATA_FLOWS = gql`
   mutation TranscendCliCreateDataFlows(
     $dataFlows: [DataFlowInput!]!
@@ -388,6 +404,16 @@ export const UPDATE_CONSENT_EXPERIENCE = gql`
 export const CREATE_CONSENT_EXPERIENCE = gql`
   mutation TranscendCliCreateConsentExperience($input: CreateExperienceInput!) {
     createExperience(input: $input) {
+      clientMutationId
+    }
+  }
+`;
+
+export const CREATE_CONSENT_PARTITION = gql`
+  mutation TranscendCliCreateConsentPartition(
+    $input: CreateConsentPartitionInput!
+  ) {
+    createConsentPartition(input: $input) {
       clientMutationId
     }
   }

--- a/src/graphql/pullTranscendConfiguration.ts
+++ b/src/graphql/pullTranscendConfiguration.ts
@@ -48,6 +48,7 @@ import { fetchAllAssessmentTemplates } from './fetchAssessmentTemplates';
 import {
   fetchConsentManager,
   fetchConsentManagerExperiences,
+  fetchConsentManagerPartitions,
   fetchConsentManagerTheme,
 } from './fetchConsentManagerId';
 import { fetchAllEnrichers } from './syncEnrichers';
@@ -149,6 +150,7 @@ export async function pullTranscendConfiguration(
     businessEntities,
     consentManager,
     consentManagerExperiences,
+    consentManagerPartitions,
     prompts,
     promptPartials,
     promptGroups,
@@ -244,6 +246,10 @@ export async function pullTranscendConfiguration(
     // Fetch consent manager experiences
     resources.includes(TranscendPullResource.ConsentManager)
       ? fetchConsentManagerExperiences(client)
+      : [],
+    // Fetch consent manager partitions
+    resources.includes(TranscendPullResource.ConsentManager)
+      ? fetchConsentManagerPartitions(client)
       : [],
     // Fetch prompts
     resources.includes(TranscendPullResource.Prompts)
@@ -350,6 +356,13 @@ export async function pullTranscendConfiguration(
             privacyPolicy: consentManagerTheme.privacyPolicy || undefined,
             prompt: consentManagerTheme.prompt,
           },
+      partitions:
+        consentManagerPartitions.length > 0
+          ? consentManagerPartitions.map(({ name, partition }) => ({
+              name,
+              partition,
+            }))
+          : undefined,
       experiences: consentManagerExperiences.map((experience) => ({
         name: experience.name,
         displayName: experience.displayName || undefined,

--- a/src/graphql/syncBusinessEntities.ts
+++ b/src/graphql/syncBusinessEntities.ts
@@ -10,6 +10,7 @@ import {
   BusinessEntity,
 } from './fetchAllBusinessEntities';
 import colors from 'colors';
+import chunk from 'lodash/chunk';
 
 /**
  * Input to create a new business entity
@@ -54,18 +55,21 @@ export async function updateBusinessEntities(
   client: GraphQLClient,
   businessEntityIdParis: [BusinessEntityInput, string][],
 ): Promise<void> {
-  await makeGraphQLRequest(client, UPDATE_BUSINESS_ENTITIES, {
-    input: businessEntityIdParis.map(([businessEntity, id]) => ({
-      id,
-      title: businessEntity.title,
-      description: businessEntity.description,
-      address: businessEntity.address,
-      headquarterCountry: businessEntity.headquarterCountry,
-      headquarterSubDivision: businessEntity.headquarterSubDivision,
-      dataProtectionOfficerName: businessEntity.dataProtectionOfficerName,
-      dataProtectionOfficerEmail: businessEntity.dataProtectionOfficerEmail,
-      attributes: businessEntity.attributes,
-    })),
+  const chunkedUpdates = chunk(businessEntityIdParis, 100);
+  await mapSeries(chunkedUpdates, async (chunked) => {
+    await makeGraphQLRequest(client, UPDATE_BUSINESS_ENTITIES, {
+      input: chunked.map(([businessEntity, id]) => ({
+        id,
+        title: businessEntity.title,
+        description: businessEntity.description,
+        address: businessEntity.address,
+        headquarterCountry: businessEntity.headquarterCountry,
+        headquarterSubDivision: businessEntity.headquarterSubDivision,
+        dataProtectionOfficerName: businessEntity.dataProtectionOfficerName,
+        dataProtectionOfficerEmail: businessEntity.dataProtectionOfficerEmail,
+        attributes: businessEntity.attributes,
+      })),
+    });
   });
 }
 

--- a/src/graphql/syncBusinessEntities.ts
+++ b/src/graphql/syncBusinessEntities.ts
@@ -30,7 +30,9 @@ export async function createBusinessEntity(
     headquarterSubDivision: businessEntity.headquarterSubDivision,
     dataProtectionOfficerName: businessEntity.dataProtectionOfficerName,
     dataProtectionOfficerEmail: businessEntity.dataProtectionOfficerEmail,
-    // TODO: https://transcend.height.app/T-31994 - add attributes, teams, owners
+    attributes: businessEntity.attributes,
+    teamNames: businessEntity.teams,
+    ownerEmails: businessEntity.owners,
   };
 
   const { createBusinessEntity } = await makeGraphQLRequest<{
@@ -68,6 +70,8 @@ export async function updateBusinessEntities(
         dataProtectionOfficerName: businessEntity.dataProtectionOfficerName,
         dataProtectionOfficerEmail: businessEntity.dataProtectionOfficerEmail,
         attributes: businessEntity.attributes,
+        teamNames: businessEntity.teams,
+        ownerEmails: businessEntity.owners,
       })),
     });
   });

--- a/transcend-yml-schema-v5.json
+++ b/transcend-yml-schema-v5.json
@@ -34009,6 +34009,30 @@
             "type": "string"
           }
         },
+        "partitions": {
+          "type": "array",
+          "items": {
+            "allOf": [
+              {
+                "type": "object",
+                "required": ["name"],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                }
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "partition": {
+                    "type": "string"
+                  }
+                }
+              }
+            ]
+          }
+        },
         "partition": {
           "type": "string"
         },

--- a/transcend-yml-schema-v5.json
+++ b/transcend-yml-schema-v5.json
@@ -11376,6 +11376,18 @@
                     }
                   }
                 }
+              },
+              "owners": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "teams": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
               }
             }
           }


### PR DESCRIPTION
- `yarn tr-pull --resources=consentManager` now includes the list of consent partitions e.g.
```yml
  partitions:
    - name: Staging
      partition: 1dd7cfef9578d0375c8eec63f364ef72c5429f4e6b732cff8ace1e65b23320a2
    - name: Dev
      partition: 3ead9290e548883c3f6e3b5899957290a6468310fb1998373bb62230a1c19a0f
```
- fixes bug when updating > 100 business entities
- adds ability for business entities to sync teams, owners, attributes on create and update