### PR TITLE
Add ability to approve requests from a specific origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -875,6 +875,7 @@ The API key needs the following scopes:
 | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | --------------- | ------------------------ | -------- |
 | auth             | The Transcend API key with the scopes necessary for the command.                                                                           | string          | N/A                      | true     |
 | actions          | The [request actions](https://docs.transcend.io/docs/privacy-requests/configuring-requests/data-subject-requests#data-actions) to approve. | RequestAction[] | N/A                      | true     |
+| origins          | The [request origins](https://github.com/transcend-io/privacy-types/blob/main/src/request.ts) to approve.                                  | RequestOrigin[] | N/A                      | false    |
 | silentModeBefore | Any requests made before this date should be marked as silent mode                                                                         | Date            | N/A                      | false    |
 | createdAtBefore  | Approve requests that were submitted before this time                                                                                      | Date            | N/A                      | false    |
 | createdAtAfter   | Approve requests that were submitted after this time                                                                                       | Date            | N/A                      | false    |
@@ -893,6 +894,12 @@ Specifying the backend URL, needed for US hosted backend infrastructure.
 
 ```sh
 yarn tr-request-approve --auth=$TRANSCEND_API_KEY --actions=ERASURE --transcendUrl=https://api.us.transcend.io
+```
+
+Approve all Erasure requests that came through the API
+
+```sh
+yarn tr-request-approve --auth=$TRANSCEND_API_KEY --actions=ERASURE --origins=API
 ```
 
 Approve all requests, but mark any request made before 05/03/2023 as silent mode to prevent emailing those requests. When not provided, the existing silent mode state of that request will be used to determine if emails are sent.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/cli",
   "description": "Small package containing useful typescript utilities.",
-  "version": "6.4.3",
+  "version": "6.5.0",
   "homepage": "https://github.com/transcend-io/cli",
   "repository": {
     "type": "git",

--- a/src/graphql/fetchAllRequests.ts
+++ b/src/graphql/fetchAllRequests.ts
@@ -79,6 +79,7 @@ export async function fetchAllRequests(
   {
     actions = [],
     statuses = [],
+    origins = [],
     createdAtBefore,
     createdAtAfter,
     isTest,
@@ -87,6 +88,8 @@ export async function fetchAllRequests(
   }: {
     /** Actions to filter on */
     actions?: RequestAction[];
+    /** Origins to filter on */
+    origins?: RequestOrigin[];
     /** Statuses to filter on */
     statuses?: RequestStatus[];
     /** Filter for requests created before this date */
@@ -132,6 +135,7 @@ export async function fetchAllRequests(
       filterBy: {
         type: actions.length > 0 ? actions : undefined,
         status: statuses.length > 0 ? statuses : undefined,
+        origin: origins.length > 0 ? origins : undefined,
         isTest,
         isSilent,
         isClosed,

--- a/src/requests/approvePrivacyRequests.ts
+++ b/src/requests/approvePrivacyRequests.ts
@@ -1,7 +1,11 @@
 import { map } from 'bluebird';
 import colors from 'colors';
 import { logger } from '../logger';
-import { RequestAction, RequestStatus } from '@transcend-io/privacy-types';
+import {
+  RequestAction,
+  RequestOrigin,
+  RequestStatus,
+} from '@transcend-io/privacy-types';
 import {
   UPDATE_PRIVACY_REQUEST,
   fetchAllRequests,
@@ -20,6 +24,7 @@ import { DEFAULT_TRANSCEND_API } from '../constants';
  */
 export async function approvePrivacyRequests({
   requestActions,
+  requestOrigins,
   auth,
   silentModeBefore,
   createdAtAfter,
@@ -29,6 +34,8 @@ export async function approvePrivacyRequests({
 }: {
   /** The request actions that should be restarted */
   requestActions: RequestAction[];
+  /** The request origins that should be restarted */
+  requestOrigins?: RequestOrigin[];
   /** Transcend API key authentication */
   auth: string;
   /** Concurrency limit for approving */
@@ -58,6 +65,7 @@ export async function approvePrivacyRequests({
     actions: requestActions,
     statuses: [RequestStatus.Approving],
     createdAtAfter,
+    origins: requestOrigins,
     createdAtBefore,
   });
 


### PR DESCRIPTION
Approve all Erasure requests that came through the API

```sh
yarn tr-request-approve --auth=$TRANSCEND_API_KEY --actions=ERASURE --origins=API
```