### PR TITLE
Updates podfile scans to handle double quotes

### DIFF
--- a/examples/code-scanning/test-requirements-txt/nested-cocoapods-2/Podfile
+++ b/examples/code-scanning/test-requirements-txt/nested-cocoapods-2/Podfile
@@ -1,0 +1,35 @@
+platform :ios, "14.0"
+use_frameworks!
+inhibit_all_warnings!
+target "Acme" do
+
+    # Raizlabs
+    pod 'RZVinyl', :git =>'git@github.com:test/acme-RZVinyl.git'
+    pod 'RZTransitions', '1.2.1'
+    # Acme
+    pod 'SDWebImage', :git =>'git@github.com:test/acme-SDWebImage.git', :commit => 'c224e87'
+
+    # Code Analysis
+    pod 'SwiftLint'
+    target 'AcmeTests' do
+        inherit! :search_paths
+        pod 'RZVinyl', :git =>'git@github.com:test/acme-RZVinyl.git'
+        # For UI Snapshot Testing
+        use_frameworks!
+        pod 'iOSSnapshotTestCase', '6.2.0'
+        pod 'SnapshotTesting', '~> 1.8.1'
+    end
+
+    target 'NotificationServiceExtension' do
+      inherit! :search_paths
+    end
+
+    post_install do |installer|
+      installer.pods_project.targets.each do |target|
+
+      target.build_configurations.each do |config|
+          config.build_settings['EXPANDED_CODE_SIGN_IDENTITY'] = ""
+        end
+      end
+    end
+end

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/cli",
   "description": "Small package containing useful typescript utilities.",
-  "version": "6.13.1",
+  "version": "6.13.2",
   "homepage": "https://github.com/transcend-io/cli",
   "repository": {
     "type": "git",
@@ -59,7 +59,7 @@
     "clean": "yarn tsc --build --clean",
     "lint": "yarn eslint src --ext .ts",
     "prepublish": "yarn build",
-    "test": "yarn mocha './src/**/*.test.ts'",
+    "test": "yarn mocha './src/**/*.test.ts' --reporter-option maxDiffSize=0",
     "script:transcend-json-schema": "ts-node --transpile-only scripts/buildTranscendJsonSchema.ts && yarn prettier ./transcend-yml-schema-v6.json --write",
     "script:pathfinder-json-schema": "ts-node --transpile-only scripts/buildPathfinderJsonSchema.ts && yarn prettier ./pathfinder-policy-yml-schema.json --write"
   },

--- a/src/code-scanning/integrations/cocoaPods.ts
+++ b/src/code-scanning/integrations/cocoaPods.ts
@@ -4,7 +4,7 @@ import { CodePackageSdk } from '../../codecs';
 import { findAllWithRegex } from '@transcend-io/type-utils';
 import { CodePackageType } from '@transcend-io/privacy-types';
 
-const POD_TARGET_REGEX = /target '(.*?)'/;
+const POD_TARGET_REGEX = /target ('|")(.*?)('|")/;
 const POD_PACKAGE_REGEX = /pod ('|")(.*?)('|")(, ('|")~> (.+?)('|")|)/;
 
 export const cocoaPods: CodeScanningConfig = {
@@ -16,7 +16,7 @@ export const cocoaPods: CodeScanningConfig = {
     const targets = findAllWithRegex(
       {
         value: new RegExp(POD_TARGET_REGEX, 'g'),
-        matches: ['name'],
+        matches: ['quote1', 'name', 'quote2'],
       },
       fileContents,
     );

--- a/src/preference-management/tests/checkIfPendingPreferenceUpdatesCauseConflict.test.ts
+++ b/src/preference-management/tests/checkIfPendingPreferenceUpdatesCauseConflict.test.ts
@@ -75,7 +75,7 @@ const PREFERENCE_TOPICS: PreferenceTopic[] = [
   },
 ];
 
-describe.only('checkIfPendingPreferenceUpdatesCauseConflict', () => {
+describe('checkIfPendingPreferenceUpdatesCauseConflict', () => {
   it('should return false for simple purpose comparison', () => {
     expect(
       checkIfPendingPreferenceUpdatesCauseConflict({

--- a/src/tests/findCodePackagesInFolder.test.ts
+++ b/src/tests/findCodePackagesInFolder.test.ts
@@ -130,6 +130,57 @@ describe('findCodePackagesInFolder', () => {
         repositoryName: 'transcend-io/cli',
       },
       {
+        name: 'Acme',
+        relativePath: 'test-requirements-txt/nested-cocoapods-2/Podfile',
+        repositoryName: 'transcend-io/cli',
+        softwareDevelopmentKits: [
+          {
+            name: 'RZVinyl',
+            version: undefined,
+          },
+          {
+            name: 'RZTransitions',
+            version: undefined,
+          },
+          {
+            name: 'SDWebImage',
+            version: undefined,
+          },
+          {
+            name: 'SwiftLint',
+            version: undefined,
+          },
+        ],
+        type: 'COCOA_PODS',
+      },
+      {
+        name: 'AcmeTests',
+        type: 'COCOA_PODS',
+        softwareDevelopmentKits: [
+          {
+            name: 'RZVinyl',
+            version: undefined,
+          },
+          {
+            name: 'iOSSnapshotTestCase',
+            version: undefined,
+          },
+          {
+            name: 'SnapshotTesting',
+            version: '1.8.1',
+          },
+        ],
+        relativePath: 'test-requirements-txt/nested-cocoapods-2/Podfile',
+        repositoryName: 'transcend-io/cli',
+      },
+      {
+        name: 'NotificationServiceExtension',
+        relativePath: 'test-requirements-txt/nested-cocoapods-2/Podfile',
+        repositoryName: 'transcend-io/cli',
+        softwareDevelopmentKits: [],
+        type: 'COCOA_PODS',
+      },
+      {
         name: 'com.yourcompany.yourapp',
         softwareDevelopmentKits: [
           {


### PR DESCRIPTION
## Related Issues

- links https://transcend.height.app/T-41591

Fixes bug in cocoapods scan where targets defined using double quotes were missed