### PR TITLE
tr-pull-datapoints should filter status based on category and includeGuessedCategories flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/cli",
   "description": "Small package containing useful typescript utilities.",
-  "version": "6.14.4",
+  "version": "6.15.0",
   "homepage": "https://github.com/transcend-io/cli",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/cli",
   "description": "Small package containing useful typescript utilities.",
-  "version": "6.14.3",
+  "version": "6.14.4",
   "homepage": "https://github.com/transcend-io/cli",
   "repository": {
     "type": "git",

--- a/src/data-inventory/pullAllDatapoints.ts
+++ b/src/data-inventory/pullAllDatapoints.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-lines */
 import keyBy from 'lodash/keyBy';
 import {
-  DataCategoryType,
+  type DataCategoryType,
   SubDataPointDataSubCategoryGuessStatus,
 } from '@transcend-io/privacy-types';
 import uniq from 'lodash/uniq';
@@ -14,12 +14,12 @@ import type { GraphQLClient } from 'graphql-request';
 import {
   DATAPOINT_EXPORT,
   DATA_SILO_EXPORT,
-  DataSiloAttributeValue,
+  type DataSiloAttributeValue,
   SUB_DATA_POINTS_COUNT,
   makeGraphQLRequest,
 } from '../graphql';
 import { logger } from '../logger';
-import { DataCategoryInput, ProcessingPurposeInput } from '../codecs';
+import type { DataCategoryInput, ProcessingPurposeInput } from '../codecs';
 import { mapSeries } from 'bluebird';
 
 export interface DataSiloCsvPreview {
@@ -119,6 +119,12 @@ async function pullSubDatapoints(
   const filterBy = {
     ...(parentCategories.length > 0 ? { category: parentCategories } : {}),
     ...(subCategories.length > 0 ? { subCategoryIds: subCategories } : {}),
+    // if parentCategories or subCategories and not includeGuessedCategories
+    ...(parentCategories.length + subCategories.length > 0 &&
+    !includeGuessedCategories
+      ? // then only show data points with approved data categories
+        { status: SubDataPointDataSubCategoryGuessStatus.Approved }
+      : {}),
     ...(dataSiloIds.length > 0 ? { dataSilos: dataSiloIds } : {}),
   };
 
@@ -140,7 +146,7 @@ async function pullSubDatapoints(
   progressBar.start(totalCount, 0);
   let total = 0;
   let shouldContinue = false;
-  let cursor;
+  let cursor: string | undefined;
   let offset = 0;
   do {
     try {


### PR DESCRIPTION
## Related Issues

- closes T-42535 tr-pull-datapoints should filter status based on category and includeGuessedCategories flag

## Security Implications

_[none]_

## System Availability

_[none]_
