### PR TITLE
improve cli-sync-ot to use JSONStream when reading from file

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -35,6 +35,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@transcend-io/privacy-types", "npm:4.108.0"],\
             ["@transcend-io/secret-value", "npm:1.2.0"],\
             ["@transcend-io/type-utils", "npm:1.8.0"],\
+            ["@types/JSONStream", [\
+              "@types/jsonstream",\
+              "npm:0.8.33"\
+            ]],\
             ["@types/bluebird", "npm:3.5.38"],\
             ["@types/chai", "npm:4.3.4"],\
             ["@types/cli-progress", "npm:3.11.0"],\
@@ -46,6 +50,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@types/inquirer-autocomplete-prompt", "npm:3.0.0"],\
             ["@types/js-yaml", "npm:4.0.5"],\
             ["@types/json-schema", "npm:7.0.15"],\
+            ["@types/jsonstream", "npm:0.8.33"],\
             ["@types/jsonwebtoken", "npm:9.0.3"],\
             ["@types/lodash", "npm:4.14.186"],\
             ["@types/mocha", "npm:10.0.1"],\
@@ -55,6 +60,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@typescript-eslint/eslint-plugin", "virtual:05f71a130d973c89ca25c909f694e525ea840a597fa145c0b76e367faaae056c000c13c8dc936d4a8d6e8c6aa1f1290e6e296ad4666bf503fd491f764698380a#npm:5.58.0"],\
             ["@typescript-eslint/parser", "virtual:05f71a130d973c89ca25c909f694e525ea840a597fa145c0b76e367faaae056c000c13c8dc936d4a8d6e8c6aa1f1290e6e296ad4666bf503fd491f764698380a#npm:5.58.0"],\
             ["@yarnpkg/sdks", "npm:3.0.0-rc.42"],\
+            ["JSONStream", "npm:1.3.5"],\
             ["bluebird", "npm:3.7.2"],\
             ["chai", "npm:4.3.7"],\
             ["cli-progress", "npm:3.11.2"],\
@@ -687,6 +693,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@transcend-io/privacy-types", "npm:4.108.0"],\
             ["@transcend-io/secret-value", "npm:1.2.0"],\
             ["@transcend-io/type-utils", "npm:1.8.0"],\
+            ["@types/JSONStream", [\
+              "@types/jsonstream",\
+              "npm:0.8.33"\
+            ]],\
             ["@types/bluebird", "npm:3.5.38"],\
             ["@types/chai", "npm:4.3.4"],\
             ["@types/cli-progress", "npm:3.11.0"],\
@@ -698,6 +708,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@types/inquirer-autocomplete-prompt", "npm:3.0.0"],\
             ["@types/js-yaml", "npm:4.0.5"],\
             ["@types/json-schema", "npm:7.0.15"],\
+            ["@types/jsonstream", "npm:0.8.33"],\
             ["@types/jsonwebtoken", "npm:9.0.3"],\
             ["@types/lodash", "npm:4.14.186"],\
             ["@types/mocha", "npm:10.0.1"],\
@@ -707,6 +718,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@typescript-eslint/eslint-plugin", "virtual:05f71a130d973c89ca25c909f694e525ea840a597fa145c0b76e367faaae056c000c13c8dc936d4a8d6e8c6aa1f1290e6e296ad4666bf503fd491f764698380a#npm:5.58.0"],\
             ["@typescript-eslint/parser", "virtual:05f71a130d973c89ca25c909f694e525ea840a597fa145c0b76e367faaae056c000c13c8dc936d4a8d6e8c6aa1f1290e6e296ad4666bf503fd491f764698380a#npm:5.58.0"],\
             ["@yarnpkg/sdks", "npm:3.0.0-rc.42"],\
+            ["JSONStream", "npm:1.3.5"],\
             ["bluebird", "npm:3.7.2"],\
             ["chai", "npm:4.3.7"],\
             ["cli-progress", "npm:3.11.2"],\
@@ -1038,6 +1050,16 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageLocation": "./.yarn/cache/@types-json5-npm-0.0.29-f63a7916bd-e60b153664.zip/node_modules/@types/json5/",\
           "packageDependencies": [\
             ["@types/json5", "npm:0.0.29"]\
+          ],\
+          "linkType": "HARD"\
+        }]\
+      ]],\
+      ["@types/jsonstream", [\
+        ["npm:0.8.33", {\
+          "packageLocation": "./.yarn/cache/@types-jsonstream-npm-0.8.33-7fb802be78-040d927d83.zip/node_modules/@types/jsonstream/",\
+          "packageDependencies": [\
+            ["@types/jsonstream", "npm:0.8.33"],\
+            ["@types/node", "npm:16.11.4"]\
           ],\
           "linkType": "HARD"\
         }]\
@@ -1578,6 +1600,17 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["fast-glob", "npm:3.2.7"],\
             ["micromatch", "npm:4.0.4"],\
             ["tslib", "npm:2.4.0"]\
+          ],\
+          "linkType": "HARD"\
+        }]\
+      ]],\
+      ["JSONStream", [\
+        ["npm:1.3.5", {\
+          "packageLocation": "./.yarn/cache/JSONStream-npm-1.3.5-1987f2e6dd-2605fa1242.zip/node_modules/JSONStream/",\
+          "packageDependencies": [\
+            ["JSONStream", "npm:1.3.5"],\
+            ["jsonparse", "npm:1.3.1"],\
+            ["through", "npm:2.3.8"]\
           ],\
           "linkType": "HARD"\
         }]\
@@ -4949,6 +4982,15 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageDependencies": [\
             ["json5", "npm:2.2.0"],\
             ["minimist", "npm:1.2.7"]\
+          ],\
+          "linkType": "HARD"\
+        }]\
+      ]],\
+      ["jsonparse", [\
+        ["npm:1.3.1", {\
+          "packageLocation": "./.yarn/cache/jsonparse-npm-1.3.1-b6fde74828-6514a7be46.zip/node_modules/jsonparse/",\
+          "packageDependencies": [\
+            ["jsonparse", "npm:1.3.1"]\
           ],\
           "linkType": "HARD"\
         }]\

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -50,7 +50,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@types/inquirer-autocomplete-prompt", "npm:3.0.0"],\
             ["@types/js-yaml", "npm:4.0.5"],\
             ["@types/json-schema", "npm:7.0.15"],\
-            ["@types/jsonstream", "npm:0.8.33"],\
             ["@types/jsonwebtoken", "npm:9.0.3"],\
             ["@types/lodash", "npm:4.14.186"],\
             ["@types/mocha", "npm:10.0.1"],\
@@ -708,7 +707,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@types/inquirer-autocomplete-prompt", "npm:3.0.0"],\
             ["@types/js-yaml", "npm:4.0.5"],\
             ["@types/json-schema", "npm:7.0.15"],\
-            ["@types/jsonstream", "npm:0.8.33"],\
             ["@types/jsonwebtoken", "npm:9.0.3"],\
             ["@types/lodash", "npm:4.14.186"],\
             ["@types/mocha", "npm:10.0.1"],\

--- a/README.md
+++ b/README.md
@@ -645,6 +645,13 @@ You can also sync to disk in json format:
 tr-sync-ot --hostname=trial.onetrust.com --oneTrustAuth=$ONE_TRUST_OAUTH_TOKEN --dryRun=true --fileFormat=json --file=./oneTrustAssessments.json
 ```
 
+Once you save the assessments into disk, you can sync them to Transcend by reading from the file instead:
+
+```sh
+# Syncs to Transcend by reading from file ./oneTrustAssessments.json
+tr-sync-ot --source=file --file=./oneTrustAssessments.json --transcendAuth=$TRANSCEND_API_KEY
+```
+
 ### tr-push
 
 Given a transcend.yml file, sync the contents up to your connected services view (https://app.transcend.io/privacy-requests/connected-services).

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/cli",
   "description": "Small package containing useful typescript utilities.",
-  "version": "6.18.0",
+  "version": "6.19.0",
   "homepage": "https://github.com/transcend-io/cli",
   "repository": {
     "type": "git",
@@ -72,6 +72,7 @@
     "@transcend-io/privacy-types": "^4.108.0",
     "@transcend-io/secret-value": "^1.2.0",
     "@transcend-io/type-utils": "^1.8.0",
+    "JSONStream": "^1.3.5",
     "bluebird": "^3.7.2",
     "cli-progress": "^3.11.2",
     "colors": "^1.4.0",
@@ -98,6 +99,7 @@
     "yargs-parser": "^21.1.1"
   },
   "devDependencies": {
+    "@types/JSONStream": "npm:@types/jsonstream@^0.8.33",
     "@types/bluebird": "^3.5.38",
     "@types/chai": "^4.3.4",
     "@types/cli-progress": "^3.11.0",
@@ -109,6 +111,7 @@
     "@types/inquirer-autocomplete-prompt": "^3.0.0",
     "@types/js-yaml": "^4.0.5",
     "@types/json-schema": "^7.0.15",
+    "@types/jsonstream": "^0.8.33",
     "@types/jsonwebtoken": "^9",
     "@types/lodash": "^4.14.186",
     "@types/mocha": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,6 @@
     "@types/inquirer-autocomplete-prompt": "^3.0.0",
     "@types/js-yaml": "^4.0.5",
     "@types/json-schema": "^7.0.15",
-    "@types/jsonstream": "^0.8.33",
     "@types/jsonwebtoken": "^9",
     "@types/lodash": "^4.14.186",
     "@types/mocha": "^10.0.1",

--- a/src/oneTrust/helpers/oneTrustAssessmentToJson.ts
+++ b/src/oneTrust/helpers/oneTrustAssessmentToJson.ts
@@ -17,7 +17,7 @@ export const oneTrustAssessmentToJson = ({
   /** The position of the assessment in the final Json object */
   index: number;
   /** The total amount of the assessments in the final Json object */
-  total: number;
+  total?: number;
   /** Whether to wrap every entry in brackets */
   wrap?: boolean;
 }): string => {
@@ -30,13 +30,13 @@ export const oneTrustAssessmentToJson = ({
   const stringifiedAssessment = JSON.stringify(assessment);
 
   // Add comma for all items except the last one
-  const comma = index < total - 1 && !wrap ? ',' : '';
+  const comma = total && index < total - 1 && !wrap ? ',' : '';
 
   // write to file
   jsonEntry = `${jsonEntry + stringifiedAssessment + comma}\n`;
 
   // end with closing bracket
-  if (index === total - 1 || wrap) {
+  if ((total && index === total - 1) || wrap) {
     jsonEntry += '\n]';
   }
 

--- a/src/oneTrust/helpers/syncOneTrustAssessmentToTranscend.ts
+++ b/src/oneTrust/helpers/syncOneTrustAssessmentToTranscend.ts
@@ -35,11 +35,13 @@ export const syncOneTrustAssessmentToTranscend = async ({
   /** The index of the assessment being written to the file */
   index: number;
   /** The total amount of assessments that we will write */
-  total: number;
+  total?: number;
 }): Promise<void> => {
   logger.info(
     colors.magenta(
-      `Writing enriched assessment ${index + 1} of ${total} to Transcend...`,
+      `Writing enriched assessment ${index + 1} ${
+        total ? `of ${total} ` : ' '
+      }to Transcend...`,
     ),
   );
 
@@ -68,7 +70,9 @@ export const syncOneTrustAssessmentToTranscend = async ({
   } catch (e) {
     logger.error(
       colors.red(
-        `Failed to sync assessment ${index + 1} of ${total} to Transcend.\n` +
+        `Failed to sync assessment ${index + 1} ${
+          total ? `of ${total} ` : ' '
+        }to Transcend.\n` +
           `\tAssessment Title: ${assessment.name}. Template Title: ${assessment.template.name}\n`,
       ),
     );

--- a/src/oneTrust/helpers/syncOneTrustAssessmentsFromFile.ts
+++ b/src/oneTrust/helpers/syncOneTrustAssessmentsFromFile.ts
@@ -1,9 +1,9 @@
 import { decodeCodec } from '@transcend-io/type-utils';
 import colors from 'colors';
 import { logger } from '../../logger';
+import JSONStream from 'JSONStream';
 
 import { createReadStream } from 'fs';
-import * as readline from 'readline';
 import { OneTrustEnrichedAssessment } from '@transcend-io/privacy-types';
 import { syncOneTrustAssessmentToTranscend } from './syncOneTrustAssessmentToTranscend';
 import { GraphQLClient } from 'graphql-request';
@@ -13,7 +13,7 @@ import { GraphQLClient } from 'graphql-request';
  *
  * @param param - the information about the source file and Transcend instance to write them to.
  */
-export const syncOneTrustAssessmentsFromFile = async ({
+export const syncOneTrustAssessmentsFromFile = ({
   transcend,
   file,
 }: {
@@ -24,46 +24,75 @@ export const syncOneTrustAssessmentsFromFile = async ({
 }): Promise<void> => {
   logger.info(`Getting list of all assessments from file ${file}...`);
 
-  // Create a readable stream from the file
-  const fileStream = createReadStream(file, {
-    encoding: 'utf-8',
-    highWaterMark: 64 * 1024, // 64KB chunks
-  });
+  return new Promise((resolve, reject) => {
+    // Create a readable stream from the file
+    const fileStream = createReadStream(file, {
+      encoding: 'utf-8',
+      highWaterMark: 64 * 1024, // 64KB chunks
+    });
 
-  // Create readline interface
-  const rl = readline.createInterface({
-    input: fileStream,
-    crlfDelay: Infinity,
-  });
+    // Create a JSONStream parser to parse the array of OneTrust assessments from the file
+    const parser = JSONStream.parse('*'); // '*' matches each element in the root array
 
-  let index = 0;
+    let index = 0;
 
-  // Process the file line by line
-  // eslint-disable-next-line no-restricted-syntax
-  for await (const line of rl) {
-    try {
-      // Parse each non-empty line and sync to transcend
-      if (line.trim()) {
+    // Pipe the file stream into the JSON parser
+    fileStream.pipe(parser);
+
+    // Handle each parsed assessment object
+    parser.on('data', async (assessment) => {
+      try {
+        // Pause the stream while processing to avoid overwhelming memory
+        parser.pause();
+
+        // Decode and validate the assessment
         const parsedAssessment = decodeCodec(
           OneTrustEnrichedAssessment,
-          line.endsWith(',') ? line.slice(0, -1) : line,
+          assessment,
         );
 
+        // Sync the assessment to transcend
         await syncOneTrustAssessmentToTranscend({
           assessment: parsedAssessment,
           transcend,
+          // FIXME: remove this hardcoded value!
           total: 2178,
           index,
         });
+
+        index += 1;
+
+        // Resume the stream after processing
+        parser.resume();
+      } catch (e) {
+        // if failed to parse a line, report error and continue
+        logger.error(
+          colors.red(
+            `Failed to parse the assessment ${index} from file '${file}': ${e.message}.`,
+          ),
+        );
       }
-      index += 1;
-    } catch (parseError) {
-      // if failed to parse a line, report error and continue
+    });
+
+    // Handle completion
+    parser.on('end', () => {
+      logger.info(`Finished processing ${index} assessments from file ${file}`);
+      resolve();
+    });
+
+    // Handle stream or parsing errors
+    parser.on('error', (error) => {
       logger.error(
-        colors.red(
-          `Failed to parse the line ${index} from file '${file}': ${parseError.message}.`,
-        ),
+        colors.red(`Error parsing file '${file}': ${error.message}`),
       );
-    }
-  }
+      reject(error);
+    });
+
+    fileStream.on('error', (error) => {
+      logger.error(
+        colors.red(`Error reading file '${file}': ${error.message}`),
+      );
+      reject(error);
+    });
+  });
 };

--- a/src/oneTrust/helpers/syncOneTrustAssessmentsFromFile.ts
+++ b/src/oneTrust/helpers/syncOneTrustAssessmentsFromFile.ts
@@ -55,8 +55,6 @@ export const syncOneTrustAssessmentsFromFile = ({
         await syncOneTrustAssessmentToTranscend({
           assessment: parsedAssessment,
           transcend,
-          // FIXME: remove this hardcoded value!
-          total: 2178,
           index,
         });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -530,7 +530,6 @@ __metadata:
     "@types/inquirer-autocomplete-prompt": ^3.0.0
     "@types/js-yaml": ^4.0.5
     "@types/json-schema": ^7.0.15
-    "@types/jsonstream": ^0.8.33
     "@types/jsonwebtoken": ^9
     "@types/lodash": ^4.14.186
     "@types/mocha": ^10.0.1
@@ -741,7 +740,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/JSONStream@npm:@types/jsonstream@^0.8.33, @types/jsonstream@npm:^0.8.33":
+"@types/JSONStream@npm:@types/jsonstream@^0.8.33":
   version: 0.8.33
   resolution: "@types/jsonstream@npm:0.8.33"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -518,6 +518,7 @@ __metadata:
     "@transcend-io/privacy-types": ^4.108.0
     "@transcend-io/secret-value": ^1.2.0
     "@transcend-io/type-utils": ^1.8.0
+    "@types/JSONStream": "npm:@types/jsonstream@^0.8.33"
     "@types/bluebird": ^3.5.38
     "@types/chai": ^4.3.4
     "@types/cli-progress": ^3.11.0
@@ -529,6 +530,7 @@ __metadata:
     "@types/inquirer-autocomplete-prompt": ^3.0.0
     "@types/js-yaml": ^4.0.5
     "@types/json-schema": ^7.0.15
+    "@types/jsonstream": ^0.8.33
     "@types/jsonwebtoken": ^9
     "@types/lodash": ^4.14.186
     "@types/mocha": ^10.0.1
@@ -538,6 +540,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": ^5.58.0
     "@typescript-eslint/parser": ^5.58.0
     "@yarnpkg/sdks": ^3.0.0-rc.42
+    JSONStream: ^1.3.5
     bluebird: ^3.7.2
     chai: ^4.3.7
     cli-progress: ^3.11.2
@@ -735,6 +738,15 @@ __metadata:
   version: 1.0.2
   resolution: "@tsconfig/node16@npm:1.0.2"
   checksum: ca94d3639714672bbfd55f03521d3f56bb6a25479bd425da81faf21f13e1e9d15f40f97377dedbbf477a5841c5b0c8f4cd1b391f33553d750b9202c54c2c07aa
+  languageName: node
+  linkType: hard
+
+"@types/JSONStream@npm:@types/jsonstream@^0.8.33, @types/jsonstream@npm:^0.8.33":
+  version: 0.8.33
+  resolution: "@types/jsonstream@npm:0.8.33"
+  dependencies:
+    "@types/node": "*"
+  checksum: 040d927d83ec13afebcbfa6c5de95fb2003a3ebc826ecb3b189db6aebb4c3a90a25a510bae5f24561ca3b1dedb976ac5b6940230c990451989ba2cd615e99d0c
   languageName: node
   linkType: hard
 
@@ -1283,6 +1295,18 @@ __metadata:
   bin:
     shell: ./lib/cli.js
   checksum: f66db59b4e3f663477c44710447b70a49fd8c9483460f4c1e2971ecd9adc4b2adf075ce05b4cad483e06e35192ddf3cac4fff6765fed172772b8f9facbd4982d
+  languageName: node
+  linkType: hard
+
+"JSONStream@npm:^1.3.5":
+  version: 1.3.5
+  resolution: "JSONStream@npm:1.3.5"
+  dependencies:
+    jsonparse: ^1.2.0
+    through: ">=2.2.7 <3"
+  bin:
+    JSONStream: ./bin.js
+  checksum: 2605fa124260c61bad38bb65eba30d2f72216a78e94d0ab19b11b4e0327d572b8d530c0c9cc3b0764f727ad26d39e00bf7ebad57781ca6368394d73169c59e46
   languageName: node
   linkType: hard
 
@@ -4112,6 +4136,13 @@ fsevents@~2.3.2:
   languageName: node
   linkType: hard
 
+"jsonparse@npm:^1.2.0":
+  version: 1.3.1
+  resolution: "jsonparse@npm:1.3.1"
+  checksum: 6514a7be4674ebf407afca0eda3ba284b69b07f9958a8d3113ef1005f7ec610860c312be067e450c569aab8b89635e332cee3696789c750692bb60daba627f4d
+  languageName: node
+  linkType: hard
+
 "jsonwebtoken@npm:^9.0.2":
   version: 9.0.2
   resolution: "jsonwebtoken@npm:9.0.2"
@@ -5900,7 +5931,7 @@ resolve@^1.18.1:
   languageName: node
   linkType: hard
 
-"through@npm:^2.3.6":
+"through@npm:>=2.2.7 <3, through@npm:^2.3.6":
   version: 2.3.8
   resolution: "through@npm:2.3.8"
   checksum: a38c3e059853c494af95d50c072b83f8b676a9ba2818dcc5b108ef252230735c54e0185437618596c790bbba8fcdaef5b290405981ffa09dce67b1f1bf190cbd


### PR DESCRIPTION
- The `cli-sync-ot` command can push assessments to Transcend by reading them from a json file. Before, we read the file line by line, so we required that each line of the json corresponded to one assessment. Now, we use the JSONStream package to read the file one assessment object at at time, regardless of how many lines they span.

## Related Issues

- closes https://transcend.height.app/T-43654

## Security Implications

- We are adding a new package dependency (`JSONStream ^1.3.5`). I did some research and didn't find any publicly available vulnerabilities. Although it's widely used (>9M weekly downloads), it hasn't been maintained since 2018 (see [github](https://github.com/dominictarr/JSONStream)).

## System Availability

_[none]_
