### PR TITLE
Set up python for pre-commit

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -15,9 +15,14 @@ RUN chsh -s /usr/bin/zsh ubuntu
 RUN SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.zsh_history" \
     && echo $SNIPPET >> "/home/ubuntu/.zshrc"
 
-# install additional OS packages.
+# Install additional OS packages including Python, Git, and build tools
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends \
+      build-essential \
+      git \
+      python3 \
+      python3-pip \
+      python3-venv \
       shellcheck \
       software-properties-common \
       tldr \
@@ -27,9 +32,21 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && mkdir -p /root/.local/share \
     && tldr -u
 
+# Install specific yarn version globally
+RUN npm install -g "yarn@2.4.3"
+
+# Install pre-commit globally (this doesn't need the repo to be present)
+RUN pip3 install pre-commit
+
 # Ensure the ubuntu user has proper permissions
 RUN chown -R ubuntu:ubuntu /home/ubuntu
 
 # Switch to the ubuntu user and set working directory
 USER ubuntu
 WORKDIR /home/ubuntu
+
+# The agent will handle:
+# 1. Cloning the repository
+# 2. Running `yarn install`
+# 3. Running `yarn tsc --build`
+# 4. Setting up pre-commit hooks

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -31,9 +31,14 @@
       "command": "yarn test"
     },
     {
-      "name": "yarn pre-commit",
-      "description": "Run pre-commit hooks",
-      "command": "yarn pre-commit"
+      "name": "pre-commit",
+      "description": "Run pre-commit hooks on changed files",
+      "command": "pre-commit"
+    },
+    {
+      "name": "pre-commit all files",
+      "description": "Run pre-commit hooks on all files",
+      "command": "pre-commit run --all-files"
     }
   ]
 }


### PR DESCRIPTION
## Related Issues

- Installs python/pip so the agent can install pre-commit properly
- Fixes the allowed command for running pre-commit hooks

## Security Implications

_[none]_

## System Availability

_[none]_
