### PR TITLE
revert rename of `transcendUrl` arg to `consentUrl` in `transcend consent upload-preferences` and fix default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ All notable changes to the Transcend CLI tools will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.0.3] - 2025-07-29
+
+### Fixed
+
+- Resolved an issue where `transcend consent upload-preferences` was incorrectly passing `consentUrl` (with default value `consent.transcend.io`) instead of `transcendUrl` (with default value `api.transcend.io`). The argument was renamed to `transcendUrl`, reverting the change to the argument name introduced in 7.0.0.
+
 ## [7.0.2] - 2025-07-23
 
 ### Fixed
@@ -102,7 +108,7 @@ All commands have been re-mapped to new commands under the `transcend` namespace
 | `tr-upload-data-flows-from-csv`                       | `transcend consent upload-data-flows-from-csv`                         |
 | `tr-upload-preferences`                               | `transcend consent upload-preferences`                                 |
 
-The previous arguments are the same, with one exception: for the `tr-upload-consent-preferences` and `tr-upload-preferences` commands, the `transcendUrl` argument has been renamed to `consentUrl`. The default value is the same—`https://consent.transcend.io` (for EU hosting)—and you can use `https://consent.us.transcend.io` for US hosting.
+The previous arguments are the same, with one exception: for the `tr-upload-consent-preferences` ~~and `tr-upload-preferences`~~ commands ([the change to `tr-upload-preferences` was reverted in 7.0.3](#703---2025-07-29)), the `transcendUrl` argument has been renamed to `consentUrl`. The default value is the same—`https://consent.transcend.io` (for EU hosting)—and you can use `https://consent.us.transcend.io` for US hosting.
 
 ## [6.0.0] - 2024-09-03
 

--- a/README.md
+++ b/README.md
@@ -2079,7 +2079,7 @@ transcend consent upload-data-flows-from-csv \
 
 ```txt
 USAGE
-  transcend consent upload-preferences (--auth value) (--partition value) [--sombraAuth value] [--consentUrl value] [--file value] [--directory value] [--dryRun] [--skipExistingRecordCheck] [--receiptFileDir value] [--skipWorkflowTriggers] [--forceTriggerWorkflows] [--skipConflictUpdates] [--isSilent] [--attributes value] [--receiptFilepath value] [--concurrency value]
+  transcend consent upload-preferences (--auth value) (--partition value) [--sombraAuth value] [--transcendUrl value] [--file value] [--directory value] [--dryRun] [--skipExistingRecordCheck] [--receiptFileDir value] [--skipWorkflowTriggers] [--forceTriggerWorkflows] [--skipConflictUpdates] [--isSilent] [--attributes value] [--receiptFilepath value] [--concurrency value]
   transcend consent upload-preferences --help
 
 Upload preference management data to your Preference Store.
@@ -2092,7 +2092,7 @@ FLAGS
       --auth                      The Transcend API key. Requires scopes: "Modify User Stored Preferences", "View Managed Consent Database Admin API", "View Preference Store Settings"
       --partition                 The partition key to download consent preferences to
      [--sombraAuth]               The Sombra internal key, use for additional authentication when self-hosting Sombra
-     [--consentUrl]               URL of the Transcend consent backend. Use https://consent.us.transcend.io for US hosting                                                              [default = https://consent.transcend.io]
+     [--transcendUrl]             URL of the Transcend backend. Use https://api.us.transcend.io for US hosting                                                                          [default = https://api.transcend.io]
      [--file]                     Path to the CSV file to load preferences from
      [--directory]                Path to the directory of CSV files to load preferences from
      [--dryRun]                   Whether to do a dry run only - will write results to receiptFilepath without updating Transcend                                                       [default = false]
@@ -2143,7 +2143,7 @@ transcend consent upload-preferences \
   --auth="$TRANSCEND_API_KEY" \
   --partition=4d1c5daa-90b7-4d18-aa40-f86a43d2c726 \
   --file=./preferences.csv \
-  --consentUrl=https://consent.us.transcend.io
+  --transcendUrl=https://api.us.transcend.io
 ```
 
 ### `transcend inventory pull`

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/cli",
   "description": "A command line interface for programmatic operations across Transcend.",
-  "version": "7.0.2",
+  "version": "7.0.3",
   "homepage": "https://github.com/transcend-io/cli",
   "repository": {
     "type": "git",

--- a/src/commands/consent/upload-preferences/command.ts
+++ b/src/commands/consent/upload-preferences/command.ts
@@ -2,8 +2,8 @@ import { buildCommand, numberParser } from '@stricli/core';
 import { ScopeName } from '@transcend-io/privacy-types';
 import {
   createAuthParameter,
-  createConsentUrlParameter,
   createSombraAuthParameter,
+  createTranscendUrlParameter,
 } from '../../../lib/cli/common-parameters';
 
 export const uploadPreferencesCommand = buildCommand({
@@ -26,7 +26,7 @@ export const uploadPreferencesCommand = buildCommand({
         brief: 'The partition key to download consent preferences to',
       },
       sombraAuth: createSombraAuthParameter(),
-      consentUrl: createConsentUrlParameter(),
+      transcendUrl: createTranscendUrlParameter(),
       file: {
         kind: 'parsed',
         parse: String,

--- a/src/commands/consent/upload-preferences/impl.ts
+++ b/src/commands/consent/upload-preferences/impl.ts
@@ -13,7 +13,7 @@ export interface UploadPreferencesCommandFlags {
   auth: string;
   partition: string;
   sombraAuth?: string;
-  consentUrl: string;
+  transcendUrl: string;
   file?: string;
   directory?: string;
   dryRun: boolean;
@@ -34,7 +34,7 @@ export async function uploadPreferences(
     auth,
     partition,
     sombraAuth,
-    consentUrl,
+    transcendUrl,
     file = '',
     directory,
     dryRun,
@@ -129,7 +129,7 @@ export async function uploadPreferences(
         sombraAuth,
         file: filePath,
         partition,
-        transcendUrl: consentUrl,
+        transcendUrl,
         skipConflictUpdates,
         skipWorkflowTriggers,
         skipExistingRecordCheck,

--- a/src/commands/consent/upload-preferences/readme.ts
+++ b/src/commands/consent/upload-preferences/readme.ts
@@ -34,7 +34,7 @@ const examples = buildExamples<UploadPreferencesCommandFlags>(
         auth: '$TRANSCEND_API_KEY',
         partition: '4d1c5daa-90b7-4d18-aa40-f86a43d2c726',
         file: './preferences.csv',
-        consentUrl: 'https://consent.us.transcend.io',
+        transcendUrl: 'https://api.us.transcend.io',
       },
     },
   ],

--- a/src/lib/preference-management/uploadPreferenceManagementPreferencesInteractive.ts
+++ b/src/lib/preference-management/uploadPreferenceManagementPreferencesInteractive.ts
@@ -9,7 +9,6 @@ import {
 import colors from 'colors';
 import { map } from '../bluebird-replace';
 import { chunk } from 'lodash-es';
-import { DEFAULT_TRANSCEND_CONSENT_API } from '../../constants';
 import { logger } from '../../logger';
 import cliProgress from 'cli-progress';
 import { parseAttributesFromString } from '../requests';
@@ -38,7 +37,7 @@ export async function uploadPreferenceManagementPreferencesInteractive({
   skipConflictUpdates = false,
   skipExistingRecordCheck = false,
   attributes = [],
-  transcendUrl = DEFAULT_TRANSCEND_CONSENT_API,
+  transcendUrl,
   forceTriggerWorkflows = false,
 }: {
   /** The Transcend API key */
@@ -52,7 +51,7 @@ export async function uploadPreferenceManagementPreferencesInteractive({
   /** The file to process */
   file: string;
   /** API URL for Transcend backend */
-  transcendUrl?: string;
+  transcendUrl: string;
   /** Whether to do a dry run */
   dryRun?: boolean;
   /** Whether to upload as isSilent */


### PR DESCRIPTION
## Related Issues

- _[none]_

## Security Implications

_[none]_

## System Availability

_[none]_
