### PR TITLE
Adds folders `artifacts` and `ui` for rendering an interactive terminal session when importing preferences

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/cli",
   "description": "A command line interface for programmatic operations across Transcend.",
-  "version": "8.0.4",
+  "version": "8.0.5",
   "homepage": "https://github.com/transcend-io/cli",
   "repository": {
     "type": "git",

--- a/src/commands/consent/upload-preferences/artifacts/ExportManager.ts
+++ b/src/commands/consent/upload-preferences/artifacts/ExportManager.ts
@@ -1,0 +1,173 @@
+/* eslint-disable no-continue */
+import { resolve } from 'node:path';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { artifactAbsPath, type ExportKindWithCsv } from './artifactAbsPath';
+import {
+  copyToClipboard,
+  openPath,
+  extractBlocks,
+  isLogError,
+  isLogWarn,
+  type ExportArtifactResult,
+  type ExportStatusMap,
+  type LogExportKind,
+  revealInFileManager,
+} from '../../../../lib/pooling';
+import { readSafe } from '../../../../lib/helpers';
+
+/**
+ * Write the exports index file with the latest paths for each export kind.
+ */
+export class ExportManager {
+  constructor(public exportsDir: string) {}
+
+  /**
+   * Get the absolute path for an export artifact based on its kind.
+   *
+   * @param kind - The kind of the export artifact
+   * @param exportStatus - The status of the export
+   * @returns The absolute path for the export artifact
+   */
+  artifactPath(
+    kind: ExportKindWithCsv,
+    exportStatus?: ExportStatusMap,
+  ): string {
+    return artifactAbsPath(
+      kind,
+      this.exportsDir,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (exportStatus as any)?.[kind],
+    );
+  }
+
+  /**
+   * Open an export artifact in the default application for that file type.
+   *
+   * @param kind - The kind of export artifact to open
+   * @param status - Optional status of the export artifact
+   * @returns An object containing the success status and the path of the artifact
+   */
+  async open(
+    kind: ExportKindWithCsv,
+    status?: ExportStatusMap,
+  ): Promise<ExportArtifactResult> {
+    const path = this.artifactPath(kind, status);
+    return { ok: await openPath(path), path };
+  }
+
+  /**
+   * Reveal an export artifact in the file manager.
+   *
+   * @param kind - The kind of export artifact to reveal
+   * @param status - Optional status of the export artifact
+   * @returns An object containing the success status and the path of the artifact
+   */
+  async reveal(
+    kind: ExportKindWithCsv,
+    status?: ExportStatusMap,
+  ): Promise<ExportArtifactResult> {
+    const path = this.artifactPath(kind, status);
+    return { ok: await revealInFileManager(path), path };
+  }
+
+  /**
+   * Copy the absolute path of an export artifact to the clipboard.
+   *
+   * @param kind - The kind of export artifact to copy
+   * @param status - Optional status of the export artifact
+   * @returns An object containing the success status and the path of the artifact
+   */
+  async copy(
+    kind: ExportKindWithCsv,
+    status?: ExportStatusMap,
+  ): Promise<ExportArtifactResult> {
+    const path = this.artifactPath(kind, status);
+    return { ok: await copyToClipboard(path), path };
+  }
+
+  /**
+   * Export combined logs from the slot log paths.
+   *
+   * @param slotLogPaths - A map of slot IDs to their log paths
+   * @param kind - The kind of logs to export
+   * @returns The absolute path to the combined logs file
+   */
+  exportCombinedLogs(
+    slotLogPaths: Map<
+      number,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { outPath?: string; errPath?: string; [k: string]: any } | undefined
+    >,
+    kind: LogExportKind,
+  ): string {
+    if (!this.exportsDir) throw new Error('exportsDir not set');
+
+    mkdirSync(this.exportsDir, { recursive: true });
+    const ts = new Date().toISOString().replace(/[:.]/g, '-');
+    const outPath = resolve(
+      this.exportsDir,
+      kind === 'error'
+        ? `combined-errors-${ts}.log`
+        : kind === 'warn'
+        ? `combined-warns-${ts}.log`
+        : kind === 'info'
+        ? `combined-info-${ts}.log`
+        : `combined-all-${ts}.log`,
+    );
+
+    const lines: string[] = [];
+
+    for (const [, paths] of slotLogPaths) {
+      if (!paths) continue;
+      if (kind === 'all') {
+        [paths.outPath, paths.errPath, paths.structuredPath]
+          .filter(Boolean)
+          .forEach((p) => {
+            const t = readSafe(p);
+            if (t) lines.push(...t.split('\n').filter(Boolean));
+          });
+        continue;
+      }
+      if (kind === 'info') {
+        const text = readSafe(paths.infoPath) || readSafe(paths.outPath);
+        if (text) lines.push(...text.split('\n').filter(Boolean));
+        continue;
+      }
+      if (kind === 'warn') {
+        let text = readSafe(paths.warnPath);
+        if (!text) {
+          const stderr = readSafe(paths.errPath);
+          if (stderr) {
+            const blocks = extractBlocks(
+              stderr,
+              (cl) => isLogWarn(cl) && !isLogError(cl),
+            );
+            if (blocks.length) text = blocks.join('\n\n');
+          }
+        }
+        if (text) lines.push(...text.split('\n').filter(Boolean));
+        continue;
+      }
+      // error
+      let text = readSafe(paths.errorPath);
+      if (!text) {
+        const stderr = readSafe(paths.errPath);
+        if (stderr) {
+          const blocks = extractBlocks(stderr, (cl) => isLogError(cl));
+          if (blocks.length) text = blocks.join('\n\n');
+        }
+      }
+      if (text) lines.push(...text.split('\n').filter(Boolean));
+    }
+
+    lines.sort((a, b) => {
+      const ta = a.match(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/)?.[0] ?? '';
+      const tb = b.match(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/)?.[0] ?? '';
+      return ta.localeCompare(tb);
+    });
+
+    writeFileSync(outPath, `${lines.join('\n')}\n`, 'utf8');
+    return outPath;
+  }
+}
+/* eslint-enable no-continue */

--- a/src/commands/consent/upload-preferences/artifacts/artifactAbsPath.ts
+++ b/src/commands/consent/upload-preferences/artifacts/artifactAbsPath.ts
@@ -1,0 +1,46 @@
+import { join, resolve } from 'node:path';
+import type { LogExportKind } from '../../../../lib/pooling';
+
+export interface ExportArtifactStatus {
+  /** The absolute path to the export artifact */
+  path: string;
+  /** The timestamp when the artifact was saved */
+  savedAt?: number;
+  /** Whether the artifact was successfully exported */
+  exported?: boolean;
+}
+
+/**
+ * The kind of export artifact to retrieve the path for.
+ */
+export type ExportKindWithCsv = LogExportKind | 'failures-csv';
+
+/**
+ * Get the absolute path for an export artifact based on its kind.
+ *
+ * @param kind - The kind of export artifact
+ * @param exportsDir - Optional directory where exports are stored
+ * @param status - Optional status of the export artifact
+ * @returns The absolute path to the export artifact
+ */
+export function artifactAbsPath(
+  kind: ExportKindWithCsv,
+  exportsDir?: string,
+  status?: ExportArtifactStatus,
+): string {
+  const fallbackName =
+    kind === 'error'
+      ? 'combined-errors.log'
+      : kind === 'warn'
+      ? 'combined-warns.log'
+      : kind === 'info'
+      ? 'combined-info.log'
+      : kind === 'all'
+      ? 'combined-all.log'
+      : 'failing-updates.csv';
+
+  const rawPath =
+    status?.path ||
+    (exportsDir ? join(exportsDir, fallbackName) : '(set exportsDir)');
+  return rawPath.startsWith('(') ? rawPath : resolve(rawPath);
+}

--- a/src/commands/consent/upload-preferences/artifacts/index.ts
+++ b/src/commands/consent/upload-preferences/artifacts/index.ts
@@ -1,0 +1,4 @@
+export * from './artifactAbsPath';
+export * from './ExportManager';
+export * from './writeExportsIndex';
+export * from './writeFailingUpdatesCsv';

--- a/src/commands/consent/upload-preferences/artifacts/tests/ExportManager.test.ts
+++ b/src/commands/consent/upload-preferences/artifacts/tests/ExportManager.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// --- Imports (safe after mocks are set up) ---
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { artifactAbsPath } from '../artifactAbsPath';
+import {
+  copyToClipboard,
+  openPath,
+  revealInFileManager,
+} from '../../../../../lib/pooling';
+import { ExportManager } from '../ExportManager';
+
+// --- Hoisted shared state for mocks ---
+const H = vi.hoisted(() => {
+  const state = {
+    files: {} as Record<string, string>,
+    extractBlocksQueue: [] as string[][],
+    fns: {
+      copyToClipboard: vi.fn(() => true),
+      openPath: vi.fn(() => true),
+      revealInFileManager: vi.fn(() => true),
+      extractBlocks: vi.fn(() => {
+        const next = state.extractBlocksQueue.shift();
+        return next ?? [];
+      }),
+      readSafe: vi.fn((p?: string) => (p ? state.files[p] ?? '' : '')),
+    },
+  };
+  return state;
+});
+
+// --- Mocks ---
+vi.mock('node:fs', () => ({
+  mkdirSync: vi.fn(),
+  writeFileSync: vi.fn(),
+}));
+
+vi.mock('../artifactAbsPath', () => ({
+  artifactAbsPath: vi.fn(
+    (kind: string, dir?: string, status?: { path?: string }) =>
+      `[abs:${kind}:${dir ?? ''}:${status?.path ?? ''}]`,
+  ),
+}));
+
+vi.mock('../../../../../lib/pooling', () => ({
+  copyToClipboard: H.fns.copyToClipboard,
+  openPath: H.fns.openPath,
+  revealInFileManager: H.fns.revealInFileManager,
+  extractBlocks: H.fns.extractBlocks,
+  isLogError: vi.fn(() => false),
+  isLogWarn: vi.fn(() => false),
+}));
+
+vi.mock('../../../../../lib/helpers', () => ({
+  readSafe: H.fns.readSafe,
+}));
+
+// --- Test Suite ---
+describe('ExportManager', () => {
+  const mMkdir = vi.mocked(mkdirSync);
+  const mWrite = vi.mocked(writeFileSync);
+  const mAbs = vi.mocked(artifactAbsPath);
+  const mCopy = vi.mocked(copyToClipboard);
+  const mOpen = vi.mocked(openPath);
+  const mReveal = vi.mocked(revealInFileManager);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-01-02T03:04:05.678Z'));
+    H.files = {};
+    H.extractBlocksQueue = [];
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function lastWrittenText(): string {
+    const { calls } = mWrite.mock;
+    const last = calls[calls.length - 1];
+    return String(last?.[1] ?? '');
+  }
+
+  it('artifactPath delegates correctly', () => {
+    const mgr = new ExportManager('/exports/dir');
+    const st = {
+      error: { path: '/custom/err.log' },
+      warn: { path: '/custom/warn.log' },
+      info: { path: '/custom/info.log' },
+      all: { path: '/custom/all.log' },
+      failuresCsv: { path: '/custom/f.csv' },
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(mgr.artifactPath('error', st as any)).toContain('/custom/err.log');
+    expect(mAbs).toHaveBeenCalled();
+  });
+
+  it('open/reveal/copy return expected objects', async () => {
+    const mgr = new ExportManager('/exports/dir');
+    mAbs.mockImplementation((k: string, d?: string) => `[abs:${k}:${d}]`);
+
+    mOpen.mockResolvedValueOnce(true);
+    await expect(mgr.open('info')).resolves.toEqual({
+      ok: true,
+      path: '[abs:info:/exports/dir]',
+    });
+
+    mReveal.mockResolvedValueOnce(false);
+    await expect(mgr.reveal('error')).resolves.toEqual({
+      ok: false,
+      path: '[abs:error:/exports/dir]',
+    });
+
+    mCopy.mockResolvedValueOnce(true);
+    await expect(mgr.copy('failures-csv')).resolves.toEqual({
+      ok: true,
+      path: '[abs:failures-csv:/exports/dir]',
+    });
+  });
+
+  it('exportCombinedLogs(all) concatenates logs in order', () => {
+    const mgr = new ExportManager('/exports');
+    H.files['/o1'] = '2024-01-01T00:00:02Z OUT1';
+    H.files['/e1'] = '2024-01-01T00:00:01Z ERR1';
+    H.files['/s1'] = '2024-01-01T00:00:03Z STR1';
+    H.files['/o2'] = '2024-01-01T00:00:00Z OUT2';
+    const map = new Map([
+      [2, { outPath: '/o2' }],
+      [1, { outPath: '/o1', errPath: '/e1', structuredPath: '/s1' }],
+    ]);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const outPath = mgr.exportCombinedLogs(map as any, 'all');
+    expect(mMkdir).toHaveBeenCalled();
+    expect(outPath).toMatch(/combined-all/);
+    expect(lastWrittenText()).toContain('OUT2');
+  });
+});

--- a/src/commands/consent/upload-preferences/artifacts/tests/artifactAbsPath.test.ts
+++ b/src/commands/consent/upload-preferences/artifacts/tests/artifactAbsPath.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { resolve, join } from 'node:path';
+import {
+  artifactAbsPath,
+  type ExportKindWithCsv,
+  type ExportArtifactStatus,
+} from '../artifactAbsPath';
+
+/**
+ * Return the expected fallback filename for a given export kind.
+ *
+ * @param kind - The export kind including CSV
+ * @returns The filename used when no status.path is provided
+ */
+function fallbackName(kind: ExportKindWithCsv): string {
+  switch (kind) {
+    case 'error':
+      return 'combined-errors.log';
+    case 'warn':
+      return 'combined-warns.log';
+    case 'info':
+      return 'combined-info.log';
+    case 'all':
+      return 'combined-all.log';
+    case 'failures-csv':
+      return 'failing-updates.csv';
+    default:
+      throw new Error(`Unknown export kind: ${kind}`);
+  }
+}
+
+describe('artifactAbsPath', () => {
+  it('returns status.path resolved when provided (absolute path stays absolute)', () => {
+    const abs: ExportArtifactStatus = { path: '/var/log/combined-errors.log' };
+    const out = artifactAbsPath('error', '/ignored', abs);
+    expect(out).toBe(resolve(abs.path)); // resolve(abs) === abs
+  });
+
+  it('returns status.path resolved when provided (relative path becomes absolute)', () => {
+    const rel: ExportArtifactStatus = { path: 'out/combined-warns.log' };
+    const out = artifactAbsPath('warn', '/ignored', rel);
+    expect(out).toBe(resolve(rel.path));
+  });
+
+  it('uses exportsDir + fallback filename when status is absent', () => {
+    const dir = '/tmp/exports';
+    (
+      ['error', 'warn', 'info', 'all', 'failures-csv'] as ExportKindWithCsv[]
+    ).forEach((k) => {
+      const expected = resolve(join(dir, fallbackName(k)));
+      const out = artifactAbsPath(k, dir);
+      expect(out).toBe(expected);
+    });
+  });
+
+  it('returns a placeholder string when neither status.path nor exportsDir is provided', () => {
+    const out = artifactAbsPath('info');
+    expect(out).toBe('(set exportsDir)'); // placeholders are not resolved
+  });
+
+  it('passes through placeholder-looking status.path without resolving', () => {
+    const status: ExportArtifactStatus = { path: '(unavailable)' };
+    const out = artifactAbsPath('all', '/ignored', status);
+    expect(out).toBe('(unavailable)');
+  });
+});

--- a/src/commands/consent/upload-preferences/artifacts/tests/writeExportsIndex.test.ts
+++ b/src/commands/consent/upload-preferences/artifacts/tests/writeExportsIndex.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import * as fs from 'node:fs';
+import * as nodeUrl from 'node:url';
+import { writeExportsIndex } from '../writeExportsIndex';
+import type { ExportStatusMap } from '../../../../../lib/pooling';
+
+/**
+ * Mock fs & url BEFORE importing the SUT.
+ * Use factories that return vi.fn()s to keep mocks hoist-safe.
+ */
+vi.mock('node:fs', () => ({
+  mkdirSync: vi.fn(),
+  writeFileSync: vi.fn(),
+}));
+vi.mock('node:url', () => ({
+  // Minimal pathToFileURL stub that yields a predictable href
+  pathToFileURL: vi.fn((p: string) => ({ href: `file://${p}` })),
+}));
+
+const mMkdir = vi.mocked(fs.mkdirSync);
+const mWrite = vi.mocked(fs.writeFileSync);
+const mPathToFileURL = vi.mocked(nodeUrl.pathToFileURL);
+
+describe('writeExportsIndex', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns undefined when exportsDir is not provided (no side effects)', () => {
+    const out = writeExportsIndex(undefined, undefined, 'exports.index.txt');
+    expect(out).toBeUndefined();
+    expect(mMkdir).not.toHaveBeenCalled();
+    expect(mWrite).not.toHaveBeenCalled();
+  });
+
+  it('writes index with absolute paths & URLs for each kind; placeholder paths keep raw URL; respects custom exportsFile; memoizes to avoid duplicate writes', () => {
+    const exportsDir = '/exp';
+    const status: ExportStatusMap = {
+      // absolute path provided → used as-is
+      error: { path: '/x/errors.log' },
+      // undefined → falls back to join(exportsDir, 'combined-warns.log')
+      warn: undefined,
+      // placeholder → url should equal placeholder (no file://)
+      info: { path: '(n/a)' },
+      // absolute path
+      all: { path: '/x/all.log' },
+      // undefined → falls back to join(exportsDir, 'failing-updates.csv')
+      failuresCsv: undefined,
+    };
+
+    const outPath = writeExportsIndex(exportsDir, status, 'custom.index.txt');
+    expect(outPath).toBe('/exp/custom.index.txt');
+
+    // directory creation & write
+    expect(mMkdir).toHaveBeenCalledWith('/exp', { recursive: true });
+    expect(mWrite).toHaveBeenCalledTimes(1);
+    expect(mWrite.mock.calls[0]?.[0]).toBe('/exp/custom.index.txt');
+    expect(mWrite.mock.calls[0]?.[2]).toBe('utf8');
+
+    const written = String(mWrite.mock.calls[0]?.[1]);
+
+    // header lines exist
+    expect(written).toContain('# Export artifacts — latest paths');
+
+    // Error: absolute path → URL via pathToFileURL
+    expect(written).toContain('Errors log:');
+    expect(written).toContain('path: /x/errors.log');
+    expect(written).toContain('url:  file:///x/errors.log');
+
+    // Warn: default fallback under exportsDir
+    expect(written).toContain('Warnings log:');
+    expect(written).toContain('path: /exp/combined-warns.log');
+    expect(written).toContain('url:  file:///exp/combined-warns.log');
+
+    // Info: placeholder → url should be identical to placeholder, no file://
+    expect(written).toContain('Info log:');
+    expect(written).toContain('path: (n/a)');
+    expect(written).toContain('url:  (n/a)');
+
+    // All: absolute path
+    expect(written).toContain('All logs:');
+    expect(written).toContain('path: /x/all.log');
+    expect(written).toContain('url:  file:///x/all.log');
+
+    // Failures CSV: fallback under exportsDir
+    expect(written).toContain('Failing updates (CSV):');
+    expect(written).toContain('path: /exp/failing-updates.csv');
+    expect(written).toContain('url:  file:///exp/failing-updates.csv');
+
+    // trailing newline
+    expect(written.endsWith('\n')).toBe(true);
+
+    // placeholder path should not pass through pathToFileURL
+    // (We called pathToFileURL for the others though)
+    const calledHrefs = mPathToFileURL.mock.calls.map((c) => c[0]);
+    expect(calledHrefs).toContain('/x/errors.log');
+    expect(calledHrefs).toContain('/exp/combined-warns.log');
+    expect(calledHrefs).toContain('/x/all.log');
+    expect(calledHrefs).toContain('/exp/failing-updates.csv');
+    expect(calledHrefs).not.toContain('(n/a)');
+
+    // Call again with identical inputs → memoization prevents a second write
+    const outPath2 = writeExportsIndex(exportsDir, status, 'custom.index.txt');
+    expect(outPath2).toBe('/exp/custom.index.txt');
+    expect(mWrite).toHaveBeenCalledTimes(1);
+
+    // Change content (e.g., different absolute path) → writes again
+    const statusChanged: ExportStatusMap = {
+      ...status,
+      error: { path: '/x/errors-changed.log' },
+    };
+    const outPath3 = writeExportsIndex(
+      exportsDir,
+      statusChanged,
+      'custom.index.txt',
+    );
+    expect(outPath3).toBe('/exp/custom.index.txt');
+    expect(mWrite).toHaveBeenCalledTimes(2);
+    const secondWrite = String(mWrite.mock.calls[1]?.[1]);
+    expect(secondWrite).toContain('path: /x/errors-changed.log');
+    expect(secondWrite).toContain('url:  file:///x/errors-changed.log');
+  });
+});

--- a/src/commands/consent/upload-preferences/artifacts/tests/writeFailingUpdatesCsv.test.ts
+++ b/src/commands/consent/upload-preferences/artifacts/tests/writeFailingUpdatesCsv.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import * as fs from 'node:fs';
+import {
+  writeFailingUpdatesCsv,
+  type FailingUpdateRow,
+} from '../writeFailingUpdatesCsv';
+
+/**
+ * Mock fs BEFORE importing the SUT.
+ * Use a factory that returns vi.fn()s to keep it hoist-safe.
+ */
+vi.mock('node:fs', () => ({
+  mkdirSync: vi.fn(),
+  writeFileSync: vi.fn(),
+}));
+
+const mMkdir = vi.mocked(fs.mkdirSync);
+const mWrite = vi.mocked(fs.writeFileSync);
+
+describe('writeFailingUpdatesCsv', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('creates parent dir (recursive), writes CSV with union headers in discovery order, escapes values, uses utf8, and returns outPath', () => {
+    const outPath = '/tmp/exports/failing-updates.csv';
+
+    // Two rows; the second introduces a new key `meta` (object) and omits `sourceFile`.
+    // This exercises:
+    //  - union header discovery order
+    //  - string escaping (quotes, commas, newlines)
+    //  - object → JSON.stringify + CSV escaping
+    const rows: Array<FailingUpdateRow & { meta?: unknown }> = [
+      {
+        primaryKey: 'u1',
+        uploadedAt: '2025-08-01T00:00:00Z',
+        error: 'bad,"oops"', // quotes + comma
+        updateJson: '{"x":1}', // string with quotes → should be doubled and quoted
+        sourceFile: '/a.csv',
+      },
+      {
+        primaryKey: 'u2',
+        uploadedAt: '2025-08-02T00:00:00Z',
+        error: 'E\nline', // newline
+        updateJson: '{"y":2}',
+        meta: { attempt: 2 }, // object → JSON.stringify then CSV-escape
+      },
+    ];
+
+    const ret = writeFailingUpdatesCsv(rows, outPath);
+    expect(ret).toBe(outPath);
+
+    // mkdirSync called for parent directory with recursive: true
+    expect(mMkdir).toHaveBeenCalledWith('/tmp/exports', { recursive: true });
+
+    // Validate writeFileSync was called once with utf8
+    expect(mWrite).toHaveBeenCalledTimes(1);
+    expect(mWrite.mock.calls[0]?.[0]).toBe(outPath);
+    expect(mWrite.mock.calls[0]?.[2]).toBe('utf8');
+
+    const written = String(mWrite.mock.calls[0]?.[1]);
+
+    // Header order comes from keys discovered across rows, in order:
+    // from row1: primaryKey, uploadedAt, error, updateJson, sourceFile
+    // from row2: meta (new key appended)
+    const expectedHeader =
+      'primaryKey,uploadedAt,error,updateJson,sourceFile,meta';
+    expect(written.startsWith(`${expectedHeader}\n`)).toBe(true);
+
+    // Row 1:
+    //  error: bad,"oops" -> "bad,""oops"""
+    //  updateJson: '{"x":1}' -> "{""x"":1}"
+    const row1 = 'u1,2025-08-01T00:00:00Z,"bad,""oops""","{""x"":1}",/a.csv,';
+    expect(written).toContain(`\n${row1}\n`);
+
+    // Row 2:
+    //  error: E\nline -> "E\nline"
+    //  updateJson: '{"y":2}' -> "{""y"":2}"
+    //  sourceFile: missing -> empty
+    //  meta: { attempt: 2 } -> "{""attempt"":2}"
+    const row2 =
+      'u2,2025-08-02T00:00:00Z,"E\nline","{""y"":2}",,"{""attempt"":2}"';
+    expect(written).toContain(row2);
+
+    // File should end with a trailing newline
+    expect(written.endsWith('\n')).toBe(true);
+  });
+
+  it('writes just a newline when rows is empty (no headers, no data)', () => {
+    const outPath = '/var/tmp/empty.csv';
+    const ret = writeFailingUpdatesCsv([], outPath);
+    expect(ret).toBe(outPath);
+
+    expect(mMkdir).toHaveBeenCalledWith('/var/tmp', { recursive: true });
+    expect(mWrite).toHaveBeenCalledTimes(1);
+
+    const content = String(mWrite.mock.calls[0]?.[1]);
+    expect(content).toBe('\n'); // one empty header line + newline
+  });
+});

--- a/src/commands/consent/upload-preferences/artifacts/writeExportsIndex.ts
+++ b/src/commands/consent/upload-preferences/artifacts/writeExportsIndex.ts
@@ -1,0 +1,57 @@
+// artifacts/indexWriter.ts
+import { join } from 'node:path';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+import { artifactAbsPath, type ExportKindWithCsv } from './artifactAbsPath';
+import type { ExportStatusMap } from '../../../../lib/pooling';
+
+let lastIndexFileContents = '';
+
+/**
+ * Get the absolute path for an export artifact based on its kind.
+ *
+ * @param exportsDir - Optional directory where exports are stored
+ * @param exportStatus - Optional status of the export artifact
+ * @param exportsFile - The name of the exports index file
+ * @returns The absolute path to the export artifact
+ */
+export function writeExportsIndex(
+  exportsDir?: string,
+  exportStatus?: ExportStatusMap,
+  exportsFile = 'exports.index.txt',
+): string | undefined {
+  if (!exportsDir) return undefined;
+  const lines: string[] = ['# Export artifacts — latest paths', ''];
+
+  const kinds: Array<
+    [
+      ExportKindWithCsv,
+      ExportStatusMap[keyof ExportStatusMap] | undefined,
+      string,
+    ]
+  > = [
+    ['error', exportStatus?.error, 'Errors log'],
+    ['warn', exportStatus?.warn, 'Warnings log'],
+    ['info', exportStatus?.info, 'Info log'],
+    ['all', exportStatus?.all, 'All logs'],
+    ['failures-csv', exportStatus?.failuresCsv, 'Failing updates (CSV)'],
+  ];
+
+  for (const [k, st, label] of kinds) {
+    const abs = artifactAbsPath(k, exportsDir, st);
+    const url = abs.startsWith('(') ? abs : pathToFileURL(abs).href;
+    lines.push(`${label}:`);
+    lines.push(`  path: ${abs}`);
+    lines.push(`  url:  ${url}`);
+    lines.push('');
+  }
+
+  const content = lines.join('\n');
+  const out = join(exportsDir, exportsFile);
+  if (content !== lastIndexFileContents) {
+    mkdirSync(exportsDir, { recursive: true });
+    writeFileSync(out, `${content}\n`, 'utf8');
+    lastIndexFileContents = content;
+  }
+  return out;
+}

--- a/src/commands/consent/upload-preferences/artifacts/writeFailingUpdatesCsv.ts
+++ b/src/commands/consent/upload-preferences/artifacts/writeFailingUpdatesCsv.ts
@@ -1,0 +1,53 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+/** A single failing update row we will output to CSV */
+export interface FailingUpdateRow {
+  /** The primary key / userId from receipts map key */
+  primaryKey: string;
+  /** When the upload attempt happened (ISO string) */
+  uploadedAt: string;
+  /** Error message */
+  error: string;
+  /** JSON-encoded "update" body (compact) */
+  updateJson: string;
+  /** Optional source file the row came from (helps triage) */
+  sourceFile?: string;
+}
+
+/**
+ * Write a CSV file for failing updates.
+ *
+ * @param rows - The rows to write to the CSV file
+ * @param outPath - The output path for the CSV file
+ * @returns The absolute path to the written CSV file
+ */
+export function writeFailingUpdatesCsv(
+  rows: FailingUpdateRow[],
+  outPath: string,
+): string {
+  mkdirSync(dirname(outPath), { recursive: true });
+  const headers = Array.from(
+    rows.reduce<Set<string>>((acc, row) => {
+      Object.keys(row || {}).forEach((k) => acc.add(k));
+      return acc;
+    }, new Set<string>()),
+  );
+  const esc = (v: unknown): string => {
+    if (v == null) return '';
+    const s =
+      typeof v === 'string'
+        ? v
+        : typeof v === 'object'
+        ? JSON.stringify(v)
+        : String(v);
+    return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+  };
+  const lines = [
+    headers.join(','),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ...rows.map((r) => headers.map((h) => esc((r as any)[h])).join(',')),
+  ];
+  writeFileSync(outPath, `${lines.join('\n')}\n`, 'utf8');
+  return outPath;
+}

--- a/src/commands/consent/upload-preferences/ui/buildFrameModel.ts
+++ b/src/commands/consent/upload-preferences/ui/buildFrameModel.ts
@@ -1,4 +1,3 @@
-// ui/frameModel.ts
 import type { ExportStatusMap, WorkerState } from '../../../../lib/pooling';
 
 export type UploadModeTotals = {

--- a/src/commands/consent/upload-preferences/ui/buildFrameModel.ts
+++ b/src/commands/consent/upload-preferences/ui/buildFrameModel.ts
@@ -1,0 +1,216 @@
+// ui/frameModel.ts
+import type { ExportStatusMap, WorkerState } from '../../../../lib/pooling';
+
+export type UploadModeTotals = {
+  /** The mode of the export, always 'upload' */
+  mode: 'upload';
+  /** Number of records successfully uploaded */
+  success: number;
+  /** Number of records skipped */
+  skipped: number;
+  /** Number of records failed */
+  error: number;
+  /** Number of records that were not processed */
+  errors: Record<string, number>;
+};
+
+export type CheckModeTotals = {
+  /** The mode of the export, always 'check' */
+  mode: 'check';
+  /** Number of records pending */
+  pendingConflicts: number;
+  /** Number of records pending safe */
+  pendingSafe: number;
+  /** Number of records pending */
+  totalPending: number;
+  /** Number of records skipped */
+  skipped: number;
+};
+
+/**
+ * Type guard for UploadModeTotals
+ *
+ * @param totals - The totals object to check
+ * @returns True if the totals object is of type UploadModeTotals, false otherwise
+ */
+export function isUploadModeTotals(
+  totals: unknown,
+): totals is UploadModeTotals {
+  return (
+    typeof totals === 'object' &&
+    totals !== null &&
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (totals as any).mode === 'upload'
+  );
+}
+
+/**
+ * Type guard for CheckModeTotals
+ *
+ * @param totals - The totals object to check
+ * @returns True if the totals object is of type CheckModeTotals, false otherwise
+ */
+export function isCheckModeTotals(totals: unknown): totals is CheckModeTotals {
+  return (
+    typeof totals === 'object' &&
+    totals !== null &&
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (totals as any).mode === 'check'
+  );
+}
+
+/**
+ * Represents the totals for either upload or check mode.
+ */
+export type AnyTotals = UploadModeTotals | CheckModeTotals;
+
+export interface RenderDashboardInput {
+  /** The size of the worker pool */
+  poolSize: number;
+  /** The number of CPU cores available */
+  cpuCount: number;
+  /** Total number of files to process */
+  filesTotal: number;
+  /** Number of files that have been completed */
+  filesCompleted: number;
+  /** Number of files that have failed */
+  filesFailed: number;
+  /** Map of worker ID to WorkerState */
+  workerState: Map<number, WorkerState>;
+  /** Totals for the current operation */
+  totals?: AnyTotals;
+  /** Throughput statistics */
+  throughput?: { successSoFar: number; r10s: number; r60s: number };
+  /** Whether this is the final render (e.g., for a summary) */
+  final?: boolean;
+  /** Directory where export artifacts are stored */
+  exportsDir?: string;
+  /** Status of the export artifacts */
+  exportStatus?: ExportStatusMap;
+}
+
+export type FrameModel = {
+  /** The input parameters for the dashboard */
+  input: RenderDashboardInput;
+  /** Number of workers currently processing files */
+  inProgress: number;
+  /** Total number of files that have been completed */
+  completedFiles: number;
+  /** Percentage of completion */
+  pct: number;
+  /** Estimated total jobs to be processed */
+  estTotalJobs?: number;
+  /** Estimated time of arrival text */
+  etaText: string;
+};
+
+/**
+ * Builds the frame model for the dashboard.
+ * This function calculates various statistics based on the input parameters
+ * and returns a FrameModel object that can be used to render the dashboard.
+ *
+ *
+ * @param input - The input parameters for the dashboard.
+ * @returns The frame model for the dashboard.
+ */
+export function buildFrameModel(input: RenderDashboardInput): FrameModel {
+  const {
+    filesTotal,
+    filesCompleted,
+    filesFailed,
+    workerState,
+    totals,
+    throughput,
+  } = input;
+
+  const inProgress = [...workerState.values()].filter((s) => s.busy).length;
+  const completedFiles = filesCompleted + filesFailed;
+  const pct =
+    filesTotal === 0
+      ? 100
+      : Math.floor((completedFiles / Math.max(1, filesTotal)) * 100);
+
+  // receipts-based estimation
+  const jobsFromReceipts =
+    totals && totals.mode === 'upload'
+      ? (totals as UploadModeTotals).success +
+        (totals as UploadModeTotals).skipped +
+        (totals as UploadModeTotals).error
+      : undefined;
+
+  const inflightJobsKnown = [...workerState.values()].reduce((sum, s) => {
+    const t = s.progress?.total ?? 0;
+    return sum + (t > 0 && s.busy ? t : 0);
+  }, 0);
+
+  const avgJobsPerCompletedFile =
+    jobsFromReceipts !== undefined && completedFiles > 0
+      ? jobsFromReceipts / completedFiles
+      : undefined;
+
+  const remainingFiles = Math.max(filesTotal - completedFiles - inProgress, 0);
+
+  let estTotalJobs: number | undefined;
+  if (avgJobsPerCompletedFile !== undefined) {
+    estTotalJobs =
+      (jobsFromReceipts ?? 0) +
+      inflightJobsKnown +
+      remainingFiles * avgJobsPerCompletedFile;
+  } else if (inProgress > 0) {
+    const avgInFlight =
+      inflightJobsKnown > 0 ? inflightJobsKnown / inProgress : 0;
+    if (avgInFlight > 0) {
+      estTotalJobs = inflightJobsKnown + remainingFiles * avgInFlight;
+    }
+  }
+
+  // ETA
+  let etaText = '';
+  if (throughput && estTotalJobs !== undefined) {
+    // Prefer receipts totals; fall back to throughput.successSoFar if not available
+    const processedSoFar =
+      jobsFromReceipts !== undefined
+        ? jobsFromReceipts
+        : throughput.successSoFar;
+
+    const remainingJobs = Math.max(estTotalJobs - processedSoFar, 0);
+
+    // Pick stable per-second rate
+    const ratePerSec = throughput.r60s > 0 ? throughput.r60s : throughput.r10s;
+    const ratePerHour = ratePerSec * 3600;
+
+    if (ratePerHour > 0 && remainingJobs > 0) {
+      // Formula: (estTotalJobs - (success + skipped + error)) / throughput per hour
+      const hoursLeft = remainingJobs / ratePerHour;
+      const secondsLeft = Math.max(1, Math.round(hoursLeft * 3600));
+      const eta = new Date(Date.now() + secondsLeft * 1000);
+
+      const days = Math.floor(secondsLeft / 86400); // 24 * 3600
+      const hours = Math.floor((secondsLeft % 86400) / 3600);
+      const minutes = Math.floor((secondsLeft % 3600) / 60);
+      const seconds = secondsLeft % 60;
+
+      let timeLeft = '';
+      if (days > 0) {
+        timeLeft = `${days}d ${hours}h ${minutes}m`;
+      } else if (hours > 0) {
+        timeLeft = `${hours}h ${minutes}m`;
+      } else if (minutes > 0) {
+        timeLeft = `${minutes}m ${seconds}s`;
+      } else {
+        timeLeft = `${seconds}s`;
+      }
+
+      etaText = `Expected completion: ${eta.toLocaleString()} (${timeLeft} left)`;
+    }
+  }
+
+  return {
+    input,
+    inProgress,
+    completedFiles,
+    pct,
+    estTotalJobs,
+    etaText,
+  };
+}

--- a/src/commands/consent/upload-preferences/ui/headerLines.ts
+++ b/src/commands/consent/upload-preferences/ui/headerLines.ts
@@ -1,0 +1,228 @@
+// ui/lines.ts
+import colors from 'colors';
+import { basename, resolve, join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import type {
+  CheckModeTotals,
+  FrameModel,
+  UploadModeTotals,
+} from './buildFrameModel';
+import { osc8Link, ExportStatusMap } from '../../../../lib/pooling';
+import type { ExportArtifactStatus } from '../artifacts/artifactAbsPath';
+
+const fmtNum = (n: number): string => n.toLocaleString();
+const fmtTime = (ts?: number): string =>
+  ts ? new Date(ts).toLocaleTimeString() : '—';
+
+/**
+ * Generates header lines for the dashboard.
+ * This includes the status of the upload, worker information, and throughput statistics.
+ *
+ * @param m - The frame model containing the dashboard input and statistics.
+ * @returns An array of strings representing the header lines.
+ */
+export function headerLines(m: FrameModel): string[] {
+  const { input, inProgress, pct, etaText } = m;
+  const {
+    poolSize,
+    cpuCount,
+    filesTotal,
+    filesCompleted,
+    filesFailed,
+    throughput,
+    exportsDir,
+    totals,
+  } = input;
+
+  const redIf = (n: number, s: string): string => (n > 0 ? colors.red(s) : s);
+  const barWidth = 40;
+  const filled = Math.floor((pct / 100) * barWidth);
+  const bar = '█'.repeat(filled) + '░'.repeat(barWidth - filled);
+
+  let estTotalJobsText = colors.dim('Est. total jobs: —');
+  if (m.estTotalJobs !== undefined) {
+    estTotalJobsText = colors.dim(
+      `Est. total jobs: ${fmtNum(Math.round(m.estTotalJobs))}`,
+    );
+  }
+
+  const header = [
+    `${colors.bold('Parallel uploader')} — ${poolSize} workers ${colors.dim(
+      `(CPU avail: ${cpuCount})`,
+    )}`,
+    `${colors.dim('Files')} ${fmtNum(filesTotal)}  ${colors.dim(
+      'Completed',
+    )} ${fmtNum(filesCompleted)}  ` +
+      `${colors.dim('Failed')} ${redIf(
+        filesFailed,
+        fmtNum(filesFailed),
+      )}  ${colors.dim('In-flight')} ${fmtNum(inProgress)}`,
+    `[${bar}] ${pct}%  ${estTotalJobsText} ${
+      etaText ? colors.magenta(etaText) : ''
+    }`,
+  ];
+  if (exportsDir) header.push(colors.dim(`Exports dir: ${exportsDir}`));
+  if (throughput) {
+    const perHour10 = Math.round(throughput.r10s * 3600);
+    const perHour60 = Math.round(throughput.r60s * 3600);
+    header.push(
+      colors.cyan(
+        `Throughput: ${fmtNum(perHour10)}/hr (1h: ${fmtNum(
+          perHour60,
+        )}/hr)  Newly uploaded: ${fmtNum(throughput.successSoFar)}`,
+      ),
+    );
+  }
+  if (totals) header.push(totalsBlock(totals));
+  return header.filter(Boolean);
+}
+
+/**
+ * Generates a block of text summarizing the upload or check mode totals.
+ *
+ * @param totals - The totals object containing upload or check mode totals.
+ * @returns A string representing the totals block.
+ */
+export function totalsBlock(
+  totals: UploadModeTotals | CheckModeTotals,
+): string {
+  if (totals.mode === 'upload') {
+    const t = totals as UploadModeTotals;
+    const errorsList = Object.entries(t.errors || {}).map(
+      ([msg, count]) =>
+        `  ${colors.red(`Count[${fmtNum(count)}]`)} ${colors.red(msg)}`,
+    );
+    return [
+      errorsList.length
+        ? `${colors.bold('Error breakdown:')}\n${errorsList.join('\n')}`
+        : '',
+      `${colors.bold('Receipts totals')} — Success: ${fmtNum(
+        t.success,
+      )}  Skipped: ${fmtNum(t.skipped)}  Error: ${
+        t.error ? colors.red(fmtNum(t.error)) : fmtNum(t.error)
+      }`,
+    ]
+      .filter(Boolean)
+      .join('\n\n');
+  }
+  const t = totals as CheckModeTotals;
+  return (
+    `${colors.bold('Receipts totals')} — Pending: ${fmtNum(t.totalPending)}  ` +
+    `PendingConflicts: ${fmtNum(t.pendingConflicts)}  PendingSafe: ${fmtNum(
+      t.pendingSafe,
+    )}  ` +
+    `Skipped: ${fmtNum(t.skipped)}`
+  );
+}
+
+/**
+ * Generates worker lines for the dashboard.
+ *
+ * @param m - The frame model containing the dashboard input and statistics.
+ * @returns An array of strings representing the worker lines.
+ */
+export function workerLines(m: FrameModel): string[] {
+  const { workerState } = m.input;
+  const miniWidth = 18;
+  return [...workerState.entries()].map(([id, s]) => {
+    const badge =
+      s.lastLevel === 'error'
+        ? colors.red('ERROR ')
+        : s.lastLevel === 'warn'
+        ? colors.yellow('WARN  ')
+        : s.busy
+        ? colors.green('WORKING')
+        : colors.dim('IDLE   ');
+    const fname = s.file ? basename(s.file) : '-';
+    const elapsed = s.startedAt
+      ? `${Math.floor((Date.now() - s.startedAt) / 1000)}s`
+      : '-';
+    const processed = s.progress?.processed ?? 0;
+    const total = s.progress?.total ?? 0;
+    const pctw = total > 0 ? Math.floor((processed / total) * 100) : 0;
+    const ff = Math.floor((pctw / 100) * miniWidth);
+    const mini =
+      total > 0
+        ? '█'.repeat(ff) + '░'.repeat(miniWidth - ff)
+        : ' '.repeat(miniWidth);
+    const miniTxt =
+      total > 0
+        ? `${fmtNum(processed)}/${fmtNum(total)} (${pctw}%)`
+        : colors.dim('—');
+    return `  [w${id}] ${badge} | ${fname} | ${elapsed} | [${mini}] ${miniTxt}`;
+  });
+}
+
+/**
+ * Generates a line for hotkeys and controls.
+ * This includes information on how to interact with the dashboard.
+ *
+ * @param poolSize - The size of the worker pool.
+ * @param final - Whether this is the final render (e.g., for a summary).
+ * @returns A string representing the hotkeys line.
+ */
+export function hotkeysLine(poolSize: number, final?: boolean): string {
+  const maxDigit = Math.min(poolSize - 1, 9);
+  const digitRange = poolSize <= 1 ? '0' : `0-${maxDigit}`;
+  const extra = poolSize > 10 ? ' (Tab/Shift+Tab for ≥10)' : '';
+  return final
+    ? colors.dim(
+        'Run complete — digits to view logs • Tab/Shift+Tab cycle • Esc/Ctrl+] detach • q to quit',
+      )
+    : colors.dim(
+        `Hotkeys: [${digitRange}] attach${extra} • e=errors • w=warnings • i=info • l=logs • Tab/Shift+Tab • Esc/Ctrl+] detach • Ctrl+C exit`,
+      );
+}
+
+/**
+ * Generates a block of text summarizing the export artifacts.
+ * This includes links to open or copy the paths of the artifacts.
+ *
+ * @param exportsDir - The directory where export artifacts are stored.
+ * @param exportStatus - The status of the export artifacts.
+ * @returns A string representing the export block.
+ */
+export function exportBlock(
+  exportsDir: string | undefined,
+  exportStatus: ExportStatusMap,
+): string {
+  const makeLine = (
+    key: 'E' | 'W' | 'I' | 'A' | 'F',
+    label: string,
+    status?: ExportArtifactStatus,
+    fallback?: string,
+  ): string => {
+    const exported = !!status?.exported;
+    const raw =
+      status?.path ||
+      (exportsDir
+        ? join(exportsDir, fallback ?? `${label.toLowerCase()}.log`)
+        : '(set exportsDir)');
+    const abs = raw.startsWith('(') ? raw : resolve(raw);
+    const url = abs.startsWith('(') ? abs : pathToFileURL(abs).href;
+    const openText = exported ? colors.green('open') : colors.dim('open');
+    const openLink = abs.startsWith('(') ? openText : osc8Link(abs, openText);
+    const time = fmtTime(status?.savedAt);
+    const dot = exported ? colors.green('●') : colors.dim('○');
+    return `${dot} ${colors.bold(`${key}=export-${label}`)}: ${openLink}  ${
+      exported ? colors.green(abs) : colors.dim(abs)
+    } ${colors.dim(`(last saved: ${time})`)}\n      ${colors.dim(
+      'url:',
+    )} ${url}`;
+  };
+
+  return [
+    colors.dim('Exports (Cmd/Ctrl-click “open” or copy the plain path):'),
+    `  ${makeLine('E', 'errors', exportStatus.error, 'combined-errors.log')}`,
+    `  ${makeLine('W', 'warns', exportStatus.warn, 'combined-warns.log')}`,
+    `  ${makeLine('I', 'info', exportStatus.info, 'combined-info.log')}`,
+    `  ${makeLine('A', 'all', exportStatus.all, 'combined-all.log')}`,
+    `  ${makeLine(
+      'F',
+      'failures-csv',
+      exportStatus.failuresCsv,
+      'failing-updates.csv',
+    )}`,
+    colors.dim('  (Also written to exports.index.txt for easy copying.)'),
+  ].join('\n');
+}

--- a/src/commands/consent/upload-preferences/ui/headerLines.ts
+++ b/src/commands/consent/upload-preferences/ui/headerLines.ts
@@ -1,4 +1,3 @@
-// ui/lines.ts
 import colors from 'colors';
 import { basename, resolve, join } from 'node:path';
 import { pathToFileURL } from 'node:url';

--- a/src/commands/consent/upload-preferences/ui/index.ts
+++ b/src/commands/consent/upload-preferences/ui/index.ts
@@ -1,0 +1,4 @@
+export * from './buildFrameModel';
+export * from './renderDashboard';
+export * from './headerLines';
+export * from './makeOnKeypressExtra';

--- a/src/commands/consent/upload-preferences/ui/makeOnKeypressExtra.ts
+++ b/src/commands/consent/upload-preferences/ui/makeOnKeypressExtra.ts
@@ -1,0 +1,145 @@
+import { join } from 'node:path';
+import {
+  showCombinedLogs,
+  type ExportStatusMap,
+  type SlotPaths,
+} from '../../../../lib/pooling';
+import {
+  writeFailingUpdatesCsv,
+  type ExportManager,
+  type FailingUpdateRow,
+} from '../artifacts';
+
+export interface MakeOnKeypressExtraArgs {
+  /** Rows that failed to update */
+  failingUpdates: FailingUpdateRow[];
+  /** Map of worker IDs to their log paths */
+  slotLogPaths: SlotPaths;
+  /** Export manager for handling export operations */
+  exportMgr: ExportManager;
+  /** Map of export statuses for different kinds of logs */
+  exportStatus: ExportStatusMap;
+  /** Callback for repainting the UI */
+  onRepaint: () => void;
+  /** Callback to pause the UI */
+  onPause: (paused: boolean) => void;
+}
+
+/**
+ * Handles keypress events for extra functionalities in the CLI.
+ *
+ * @param args - Configuration for the keypress handler.
+ * @returns A function that processes keypress events.
+ */
+export function makeOnKeypressExtra({
+  slotLogPaths,
+  exportMgr,
+  failingUpdates,
+  exportStatus,
+  onRepaint,
+  onPause,
+}: MakeOnKeypressExtraArgs): (buf: Buffer) => void {
+  const noteExport = (slot: keyof ExportStatusMap, p: string): void => {
+    const now = Date.now();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const current: any = exportStatus[slot] || { path: p };
+    // eslint-disable-next-line no-param-reassign
+    exportStatus[slot] = {
+      path: p || current.path,
+      savedAt: now,
+      exported: true,
+    };
+    onRepaint();
+  };
+
+  const view = (
+    sources: Array<'out' | 'err' | 'structured' | 'warn' | 'info'>,
+    level: 'error' | 'warn' | 'all',
+  ): void => {
+    onPause(true);
+    showCombinedLogs(slotLogPaths, sources, level);
+  };
+
+  return (buf: Buffer): void => {
+    const s = buf.toString('utf8');
+
+    // viewers (lowercase)
+    if (s === 'e') {
+      view(['err'], 'error');
+      return;
+    }
+    if (s === 'w') {
+      view(['warn', 'err'], 'warn');
+      return;
+    }
+    if (s === 'i') {
+      view(['info'], 'all');
+      return;
+    }
+    if (s === 'l') {
+      view(['out', 'err', 'structured'], 'all');
+      return;
+    }
+
+    // exports (uppercase)
+    if (s === 'E') {
+      try {
+        const p = exportMgr.exportCombinedLogs(slotLogPaths, 'error');
+        process.stdout.write(`\nWrote combined error logs to: ${p}\n`);
+        noteExport('error', p);
+      } catch {
+        process.stdout.write('\nFailed to write combined error logs\n');
+      }
+      return;
+    }
+    if (s === 'W') {
+      try {
+        const p = exportMgr.exportCombinedLogs(slotLogPaths, 'warn');
+        process.stdout.write(`\nWrote combined warn logs to: ${p}\n`);
+        noteExport('warn', p);
+      } catch {
+        process.stdout.write('\nFailed to write combined warn logs\n');
+      }
+      return;
+    }
+    if (s === 'I') {
+      try {
+        const p = exportMgr.exportCombinedLogs(slotLogPaths, 'info');
+        process.stdout.write(`\nWrote combined info logs to: ${p}\n`);
+        noteExport('info', p);
+      } catch {
+        process.stdout.write('\nFailed to write combined info logs\n');
+      }
+      return;
+    }
+    if (s === 'A') {
+      try {
+        const p = exportMgr.exportCombinedLogs(slotLogPaths, 'all');
+        process.stdout.write(`\nWrote combined ALL logs to: ${p}\n`);
+        noteExport('all', p);
+      } catch {
+        process.stdout.write('\nFailed to write combined ALL logs\n');
+      }
+      return;
+    }
+    if (s === 'F') {
+      try {
+        const fPath = join(exportMgr.exportsDir, 'failing-updates.csv');
+        writeFailingUpdatesCsv(failingUpdates, fPath);
+        process.stdout.write(`\nWrote failing updates CSV to: ${fPath}\n`);
+        noteExport('failuresCsv', fPath);
+      } catch (err) {
+        process.stdout.write(
+          `\nFailed to write failing updates CSV - ${err.stack}\n`,
+        );
+      }
+      return;
+    }
+
+    // back to dashboard
+    if (s === '\x1b' || s === '\x1d') {
+      onPause(false);
+      onRepaint();
+    }
+  };
+}

--- a/src/commands/consent/upload-preferences/ui/renderDashboard.ts
+++ b/src/commands/consent/upload-preferences/ui/renderDashboard.ts
@@ -1,4 +1,3 @@
-// ui/render.ts
 import * as readline from 'node:readline';
 import { buildFrameModel, type RenderDashboardInput } from './buildFrameModel';
 import {

--- a/src/commands/consent/upload-preferences/ui/renderDashboard.ts
+++ b/src/commands/consent/upload-preferences/ui/renderDashboard.ts
@@ -1,0 +1,47 @@
+// ui/render.ts
+import * as readline from 'node:readline';
+import { buildFrameModel, type RenderDashboardInput } from './buildFrameModel';
+import {
+  exportBlock,
+  headerLines,
+  hotkeysLine,
+  workerLines,
+} from './headerLines';
+import { writeExportsIndex } from '../artifacts/writeExportsIndex';
+
+let lastFrame = '';
+
+/**
+ * Renders the dashboard for the upload preferences command.
+ * This function builds the frame model and writes the exports index.
+ * It then constructs the header, worker lines, hotkeys line, and export block,
+ * and outputs the complete frame to the console.
+ *
+ * @param input - The input parameters for rendering the dashboard.
+ */
+export function renderDashboard(input: RenderDashboardInput): void {
+  const m = buildFrameModel(input);
+  writeExportsIndex(input.exportsDir, input.exportStatus);
+
+  const frame = [
+    ...headerLines(m),
+    '',
+    ...workerLines(m),
+    '',
+    hotkeysLine(input.poolSize, input.final),
+    '',
+    exportBlock(input.exportsDir, input.exportStatus ?? {}),
+  ].join('\n');
+
+  if (!input.final && frame === lastFrame) return;
+  lastFrame = frame;
+
+  if (!input.final) {
+    process.stdout.write('\x1b[?25l');
+    readline.cursorTo(process.stdout, 0, 0);
+    readline.clearScreenDown(process.stdout);
+  } else {
+    process.stdout.write('\x1b[?25h');
+  }
+  process.stdout.write(`${frame}\n`);
+}

--- a/src/commands/consent/upload-preferences/ui/tests/buildFrameModel.test.ts
+++ b/src/commands/consent/upload-preferences/ui/tests/buildFrameModel.test.ts
@@ -1,0 +1,304 @@
+// src/commands/consent/upload-preferences/ui/__tests__/frameModel.test.ts
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import {
+  buildFrameModel,
+  isUploadModeTotals,
+  isCheckModeTotals,
+  type UploadModeTotals,
+  type CheckModeTotals,
+  type RenderDashboardInput,
+} from '../buildFrameModel';
+import type { WorkerState } from '../../../../../lib/pooling';
+
+/* -----------------------------------------------------------------------------
+  Local test-only types & helpers
+----------------------------------------------------------------------------- */
+
+/**
+ * Minimal shape used by buildFrameModel at runtime for a worker.
+ * We keep it local to avoid importing runtime-only types from external modules.
+ */
+type TWorkerState = {
+  /** Whether the worker is currently processing */
+  busy: boolean;
+  /** Optional progress data */
+  progress?: {
+    /** Total planned records for the current file */
+    total?: number;
+    /** Cumulative successes for the current file (not required by SUT) */
+    successTotal?: number;
+    /** File total (not required by SUT) */
+    fileTotal?: number;
+  };
+};
+
+/**
+ * Build a Map of worker states keyed by worker id.
+ *
+ * @param entries - Worker id to state tuples
+ * @returns A Map of worker states
+ */
+function workerMap(
+  entries: Array<[number, TWorkerState]>,
+): Map<number, WorkerState> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return new Map<number, WorkerState>(entries as any);
+}
+
+/**
+ * Construct a baseline RenderDashboardInput with overridable fields.
+ *
+ * @param overrides - Partial overrides
+ * @returns A RenderDashboardInput
+ */
+function makeInput(
+  overrides: Partial<RenderDashboardInput> = {},
+): RenderDashboardInput {
+  return {
+    poolSize: 4,
+    cpuCount: 8,
+    filesTotal: 0,
+    filesCompleted: 0,
+    filesFailed: 0,
+    // Cast to the SUT's expected Map<number, WorkerState> to avoid leaking test-only types
+    workerState: workerMap([]),
+    ...overrides,
+  } as RenderDashboardInput;
+}
+
+/* -----------------------------------------------------------------------------
+  Type guards
+----------------------------------------------------------------------------- */
+
+describe('type guards', () => {
+  it('isUploadModeTotals returns true only for upload mode', () => {
+    const good: UploadModeTotals = {
+      mode: 'upload',
+      success: 1,
+      skipped: 2,
+      error: 3,
+      errors: {},
+    };
+    expect(isUploadModeTotals(good)).toBe(true);
+
+    const badMode: unknown = { mode: 'check' };
+    expect(isUploadModeTotals(badMode)).toBe(false);
+
+    expect(isUploadModeTotals(null)).toBe(false);
+    expect(isUploadModeTotals(undefined)).toBe(false);
+    expect(isUploadModeTotals({})).toBe(false);
+  });
+
+  it('isCheckModeTotals returns true only for check mode', () => {
+    const good: CheckModeTotals = {
+      mode: 'check',
+      pendingConflicts: 1,
+      pendingSafe: 2,
+      totalPending: 3,
+      skipped: 4,
+    };
+    expect(isCheckModeTotals(good)).toBe(true);
+
+    const badMode: unknown = { mode: 'upload' };
+    expect(isCheckModeTotals(badMode)).toBe(false);
+
+    expect(isCheckModeTotals(null)).toBe(false);
+    expect(isCheckModeTotals(undefined)).toBe(false);
+    expect(isCheckModeTotals({})).toBe(false);
+  });
+});
+
+/* -----------------------------------------------------------------------------
+  buildFrameModel — core stats
+----------------------------------------------------------------------------- */
+
+describe('buildFrameModel — core stats', () => {
+  it('computes inProgress, completedFiles, pct (normal case)', () => {
+    const wm = workerMap([
+      [1, { busy: true, progress: { total: 20 } }],
+      [2, { busy: false }],
+      [3, { busy: true, progress: { total: 5 } }],
+    ]);
+
+    const input: RenderDashboardInput = makeInput({
+      filesTotal: 10,
+      filesCompleted: 3,
+      filesFailed: 2,
+      workerState: wm as Map<number, WorkerState>,
+    });
+
+    const fm = buildFrameModel(input);
+
+    expect(fm.inProgress).toBe(2);
+    expect(fm.completedFiles).toBe(5);
+    expect(fm.pct).toBe(50);
+  });
+
+  it('pct is 100 when filesTotal is 0 (avoid div by zero)', () => {
+    const input: RenderDashboardInput = makeInput({
+      filesTotal: 0,
+      filesCompleted: 0,
+      filesFailed: 0,
+      workerState: workerMap([]) as Map<number, WorkerState>,
+    });
+
+    const fm = buildFrameModel(input);
+    expect(fm.pct).toBe(100);
+  });
+});
+
+/* -----------------------------------------------------------------------------
+  buildFrameModel — estTotalJobs with receipts path
+----------------------------------------------------------------------------- */
+
+describe('buildFrameModel — estTotalJobs (receipts-based)', () => {
+  it('uses receipts + inflight + remainingFiles * avg-per-completed', () => {
+    // jobsFromReceipts = 115
+    const totals: UploadModeTotals = {
+      mode: 'upload',
+      success: 100,
+      skipped: 10,
+      error: 5,
+      errors: {},
+    };
+
+    // completedFiles = 3 + 2 = 5
+    // inProgress = 2, inflightJobsKnown = 20 + 30 = 50
+    // remainingFiles = 10 - 5 - 2 = 3
+    // avgJobsPerCompletedFile = 115 / 5 = 23
+    // estTotalJobs = 115 + 50 + (3 * 23) = 234
+    const wm = workerMap([
+      [1, { busy: true, progress: { total: 20 } }],
+      [2, { busy: true, progress: { total: 30 } }],
+      [3, { busy: false }],
+    ]);
+
+    const input: RenderDashboardInput = makeInput({
+      filesTotal: 10,
+      filesCompleted: 3,
+      filesFailed: 2,
+      workerState: wm,
+      totals,
+    });
+
+    const fm = buildFrameModel(input);
+    expect(fm.estTotalJobs).toBe(234);
+  });
+});
+
+/* -----------------------------------------------------------------------------
+  buildFrameModel — ETA string (minutes/seconds branch)
+----------------------------------------------------------------------------- */
+
+describe('buildFrameModel — ETA text', () => {
+  let restoreTime: () => void;
+
+  beforeEach((): void => {
+    const fixed = new Date('2025-01-01T12:00:00.000Z');
+    vi.useFakeTimers();
+    vi.setSystemTime(fixed);
+    restoreTime = (): void => {
+      vi.useRealTimers();
+    };
+  });
+
+  afterEach((): void => {
+    restoreTime();
+  });
+
+  it('formats ETA when r60s > 0 (prefers 60s rate) and remainingJobs > 0', () => {
+    // From prior math: estTotalJobs = 234, jobsFromReceipts = 115 -> remainingJobs = 119
+    // r60s = 1 job/sec -> 3600 jobs/hour -> ~119 seconds => "1m 59s"
+    const totals: UploadModeTotals = {
+      mode: 'upload',
+      success: 100,
+      skipped: 10,
+      error: 5,
+      errors: {},
+    };
+
+    const wm = workerMap([
+      [1, { busy: true, progress: { total: 20 } }],
+      [2, { busy: true, progress: { total: 30 } }],
+      [3, { busy: false }],
+    ]);
+
+    const input: RenderDashboardInput = makeInput({
+      filesTotal: 10,
+      filesCompleted: 3,
+      filesFailed: 2,
+      workerState: wm,
+      totals,
+      throughput: { successSoFar: 9999, r10s: 0.5, r60s: 1 },
+    });
+
+    const fm = buildFrameModel(input);
+
+    expect(fm.estTotalJobs).toBe(234);
+    expect(fm.etaText).toMatch(/^Expected completion: .+ \(1m 59s left\)$/);
+  });
+
+  it('omits ETA when throughput is missing or remaining is zero', () => {
+    const totals: UploadModeTotals = {
+      mode: 'upload',
+      success: 10,
+      skipped: 0,
+      error: 0,
+      errors: {},
+    };
+
+    const inputNoThroughput: RenderDashboardInput = makeInput({
+      filesTotal: 1,
+      filesCompleted: 0,
+      filesFailed: 0,
+      workerState: workerMap([[1, { busy: true, progress: { total: 10 } }]]),
+      totals,
+    });
+
+    const fm1 = buildFrameModel(inputNoThroughput);
+    expect(fm1.etaText).toBe('');
+
+    const inputZeroRemaining: RenderDashboardInput = makeInput({
+      filesTotal: 1,
+      filesCompleted: 1,
+      filesFailed: 0,
+      workerState: workerMap([]),
+      totals,
+      throughput: { successSoFar: 10, r10s: 1, r60s: 1 },
+    });
+
+    const fm2 = buildFrameModel(inputZeroRemaining);
+    expect(fm2.etaText).toBe('');
+  });
+});
+
+/* -----------------------------------------------------------------------------
+  buildFrameModel — estTotalJobs without receipts (in-flight only path)
+----------------------------------------------------------------------------- */
+
+describe('buildFrameModel — estTotalJobs (in-flight path, no receipts)', () => {
+  it('falls back to in-flight average when no receipts are available', () => {
+    // inProgress = 2, inflightKnown = 12 + 38 = 50
+    // remainingFiles = 7 - (2 completed + 1 failed) - 2 inProgress = 2
+    // avgInFlight = 50 / 2 = 25
+    // est = 50 + 2 * 25 = 100
+    const wm = workerMap([
+      [1, { busy: true, progress: { total: 12 } }],
+      [2, { busy: true, progress: { total: 38 } }],
+      [3, { busy: false }],
+    ]);
+
+    const input: RenderDashboardInput = makeInput({
+      filesTotal: 7,
+      filesCompleted: 2,
+      filesFailed: 1,
+      workerState: wm,
+      totals: undefined,
+      throughput: { successSoFar: 0, r10s: 0.8, r60s: 0 },
+    });
+
+    const fm = buildFrameModel(input);
+    expect(fm.estTotalJobs).toBe(100);
+  });
+});

--- a/src/commands/consent/upload-preferences/ui/tests/buildFrameModel.test.ts
+++ b/src/commands/consent/upload-preferences/ui/tests/buildFrameModel.test.ts
@@ -1,4 +1,3 @@
-// src/commands/consent/upload-preferences/ui/__tests__/frameModel.test.ts
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 import {

--- a/src/commands/consent/upload-preferences/ui/tests/headerLines.test.ts
+++ b/src/commands/consent/upload-preferences/ui/tests/headerLines.test.ts
@@ -1,0 +1,258 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { pathToFileURL } from 'node:url';
+
+import {
+  headerLines,
+  totalsBlock,
+  workerLines,
+  hotkeysLine,
+  exportBlock,
+} from '../headerLines';
+
+const H = vi.hoisted(() => ({
+  osc8Spy: vi.fn((abs: string, label?: string) => `[OSC8:${label ?? abs}]`),
+}));
+
+// Mock colors as identity fns for simpler assertions
+vi.mock('colors', () => {
+  const id = (s: string): string => s;
+  return {
+    default: {
+      bold: id,
+      dim: id,
+      red: id,
+      green: id,
+      yellow: id,
+      cyan: id,
+      magenta: id,
+    },
+  };
+});
+
+// Mock osc8Link via the exact module path used by the SUT
+vi.mock('../../../../../lib/pooling', () => ({
+  osc8Link: H.osc8Spy,
+}));
+
+/* -------------------------------- Test body -------------------------------- */
+describe('headerLines', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-01-02T03:04:05.000Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('headerLines: renders uploader header, files stats, progress bar, exports dir, throughput, and est jobs', () => {
+    const model = {
+      input: {
+        poolSize: 3,
+        cpuCount: 8,
+        filesTotal: 10,
+        filesCompleted: 4,
+        filesFailed: 1,
+        exportsDir: '/exp',
+        throughput: { r10s: 1, r60s: 0.5, successSoFar: 7 },
+      },
+      inProgress: 2,
+      pct: 50,
+      etaText: '~1m',
+      estTotalJobs: 1234.4,
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const lines = headerLines(model as any);
+
+    expect(lines[0]).toContain('Parallel uploader');
+    expect(lines[0]).toContain('3 workers');
+    expect(lines[0]).toContain('(CPU avail: 8)');
+
+    expect(lines[1]).toContain('Files 10');
+    expect(lines[1]).toContain('Completed 4');
+    expect(lines[1]).toContain('Failed 1');
+    expect(lines[1]).toContain('In-flight 2');
+
+    // Progress bar line includes percentage and ETA
+    expect(lines[2]).toContain('50%');
+    expect(lines[2]).toContain('~1m');
+
+    // Exports dir
+    expect(lines.some((l) => l.includes('Exports dir: /exp'))).toBe(true);
+
+    // Throughput: 1 * 3600 = 3600/hr; 0.5 * 3600 = 1800/hr
+    expect(
+      lines.some((l) => l.includes('Throughput: 3,600/hr (1h: 1,800/hr)')),
+    ).toBe(true);
+
+    // Est total jobs rounded
+    expect(lines[2]).toContain('Est. total jobs: 1,234');
+  });
+
+  it('totalsBlock: upload mode shows error breakdown and receipts totals', () => {
+    const uploadTotals = {
+      mode: 'upload',
+      success: 2,
+      skipped: 3,
+      error: 1,
+      errors: { Oops: 2, Bad: 1 },
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const out = totalsBlock(uploadTotals as any);
+    expect(out).toContain('Error breakdown:');
+    expect(out).toContain('Count[2] Oops');
+    expect(out).toContain('Count[1] Bad');
+    expect(out).toContain('Receipts totals');
+    expect(out).toContain('Success: 2');
+    expect(out).toContain('Skipped: 3');
+    expect(out).toContain('Error: 1');
+  });
+
+  it('totalsBlock: check mode summarizes pending and skipped', () => {
+    const checkTotals = {
+      mode: 'check',
+      totalPending: 5,
+      pendingConflicts: 2,
+      pendingSafe: 3,
+      skipped: 1,
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const out = totalsBlock(checkTotals as any);
+    expect(out).toContain('Receipts totals');
+    expect(out).toContain('Pending: 5');
+    expect(out).toContain('PendingConflicts: 2');
+    expect(out).toContain('PendingSafe: 3');
+    expect(out).toContain('Skipped: 1');
+  });
+
+  it('workerLines: shows status badges, filename, elapsed, and mini progress bar', () => {
+    const now = Date.now();
+    const workerState = new Map<number, unknown>([
+      [
+        1,
+        {
+          busy: true,
+          file: '/path/to/file1.csv',
+          startedAt: now - 5000,
+          lastLevel: 'ok',
+          progress: { processed: 50, total: 100 },
+        },
+      ],
+      [
+        2,
+        {
+          busy: false,
+          file: null,
+          startedAt: null,
+          lastLevel: 'warn',
+          progress: undefined,
+        },
+      ],
+      [
+        3,
+        {
+          busy: false,
+          file: null,
+          startedAt: null,
+          lastLevel: 'error',
+          progress: undefined,
+        },
+      ],
+    ]);
+
+    const model = {
+      input: { workerState },
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const lines = workerLines(model as any);
+
+    // w1: WORKING, file basename, ~5s elapsed, 50/100 and 50% mini bar (18 cols => 9 filled)
+    const l1 = lines.find((s) => s.includes('[w1]'))!;
+    expect(l1).toContain('WORKING');
+    expect(l1).toContain('file1.csv');
+    expect(l1).toContain('5s');
+    expect(l1).toContain('50/100 (50%)');
+    expect(l1).toMatch(/\[█{9}░{9}\]/);
+
+    // w2: WARN badge, idle mini text
+    const l2 = lines.find((s) => s.includes('[w2]'))!;
+    expect(l2).toContain('WARN');
+    expect(l2).toContain('—'); // dim mini text for no totals
+
+    // w3: ERROR badge
+    const l3 = lines.find((s) => s.includes('[w3]'))!;
+    expect(l3).toContain('ERROR');
+  });
+
+  it('hotkeysLine: varies by pool size and final flag', () => {
+    expect(hotkeysLine(1)).toContain('Hotkeys: [0] attach');
+    expect(hotkeysLine(5)).toContain('Hotkeys: [0-4] attach');
+    expect(hotkeysLine(15)).toContain('(Tab/Shift+Tab for ≥10)');
+
+    expect(hotkeysLine(3, true)).toContain(
+      'Run complete — digits to view logs',
+    );
+    expect(hotkeysLine(3, true)).toContain('q to quit');
+  });
+
+  it('exportBlock: renders lines with resolved paths, OSC8 open links, and file:// URLs', () => {
+    const exportStatus = {
+      error: {
+        path: '/exp/combined-errors.log',
+        savedAt: 1700000000000,
+        exported: true,
+      },
+      warn: {
+        path: '/exp/combined-warns.log',
+        savedAt: 1700000001000,
+        exported: false,
+      },
+      info: {
+        path: '/exp/combined-info.log',
+        savedAt: 1700000002000,
+        exported: true,
+      },
+      all: {
+        path: '/exp/combined-all.log',
+        savedAt: 1700000003000,
+        exported: true,
+      },
+      failuresCsv: {
+        path: '/exp/failing-updates.csv',
+        savedAt: 1700000004000,
+        exported: false,
+      },
+    };
+
+    const out = exportBlock('/exp', exportStatus);
+    // Labels and keys present
+    expect(out).toContain('E=export-errors');
+    expect(out).toContain('W=export-warns');
+    expect(out).toContain('I=export-info');
+    expect(out).toContain('A=export-all');
+    expect(out).toContain('F=export-failures-csv');
+
+    // “open” hyperlinks generated via osc8Link for absolute paths
+    expect(H.osc8Spy).toHaveBeenCalled();
+    expect(out).toContain('[OSC8:open]');
+
+    // Absolute paths and file:// URLs appear
+    const { href } = pathToFileURL('/exp/combined-errors.log');
+    expect(out).toContain('/exp/combined-errors.log');
+    expect(out).toContain(href);
+  });
+
+  it('exportBlock: when exportsDir is undefined and no status path, shows placeholder and does not call osc8Link', () => {
+    const exportStatus = {
+      error: undefined,
+      warn: undefined,
+      info: undefined,
+      all: undefined,
+      failuresCsv: undefined,
+    } as unknown as Record<string, unknown>;
+    const out = exportBlock(undefined, exportStatus);
+    expect(out).toContain('(set exportsDir)');
+    expect(H.osc8Spy).not.toHaveBeenCalled();
+  });
+});

--- a/src/commands/consent/upload-preferences/ui/tests/makeOnKeypressExtra.test.ts
+++ b/src/commands/consent/upload-preferences/ui/tests/makeOnKeypressExtra.test.ts
@@ -1,0 +1,252 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import type { ExportStatusMap, SlotPaths } from '../../../../../lib/pooling';
+import {
+  makeOnKeypressExtra,
+  type MakeOnKeypressExtraArgs,
+} from '../makeOnKeypressExtra';
+
+import { showCombinedLogs } from '../../../../../lib/pooling';
+import {
+  writeFailingUpdatesCsv,
+  type ExportManager,
+  type FailingUpdateRow,
+} from '../../artifacts';
+
+// ---- Mocks (must be defined before SUT side-effects are exercised) ----
+vi.mock('../../../../../lib/pooling', () => ({
+  showCombinedLogs: vi.fn(),
+}));
+vi.mock('../../artifacts', () => ({
+  writeFailingUpdatesCsv: vi.fn(),
+}));
+
+// ---- Fixtures & helpers ------------------------------------------------
+
+/**
+ * Create a minimal fake ExportManager with a controllable implementation.
+ *
+ * @param impl - Optional per-level return values or error
+ * @returns A fake ExportManager
+ */
+function makeFakeExportManager(impl?: {
+  /** When set, exportCombinedLogs will throw for this level */
+  throwForLevel?: 'error' | 'warn' | 'info' | 'all';
+  /** Optional explicit return path per level */
+  paths?: Partial<Record<'error' | 'warn' | 'info' | 'all', string>>;
+}): ExportManager {
+  const em = {
+    exportsDir: '/exp',
+    exportCombinedLogs: (
+      _: SlotPaths,
+      level: 'error' | 'warn' | 'info' | 'all',
+    ): string => {
+      if (impl?.throwForLevel === level) throw new Error(`boom:${level}`);
+      return impl?.paths?.[level] ?? `/exp/combined-${level}.log`;
+    },
+  };
+  return em as ExportManager;
+}
+
+/**
+ * Build a default set of args for makeOnKeypressExtra.
+ *
+ * @returns Tuple of [args, spies, handler, exportStatus]
+ */
+function buildArgs(): {
+  args: Parameters<typeof makeOnKeypressExtra>[0];
+  onPauseSpy: ReturnType<typeof vi.fn<(p: boolean) => void>>;
+  onRepaintSpy: ReturnType<typeof vi.fn<() => void>>;
+  handler: (buf: Buffer) => void;
+  exportStatus: ExportStatusMap;
+} {
+  const onPauseSpy = vi.fn<(p: boolean) => void>();
+  const onRepaintSpy = vi.fn<() => void>();
+
+  const exportStatus: ExportStatusMap = {
+    error: undefined,
+    warn: undefined,
+    info: undefined,
+    all: undefined,
+    failuresCsv: undefined,
+  };
+
+  const args: MakeOnKeypressExtraArgs = {
+    slotLogPaths: new Map() as unknown as SlotPaths,
+    exportMgr: makeFakeExportManager(),
+    failingUpdates: [
+      { id: 'abc', reason: 'nope' },
+    ] as unknown as Array<FailingUpdateRow>,
+    exportStatus,
+    onRepaint: onRepaintSpy,
+    onPause: onPauseSpy,
+  };
+
+  const handler = makeOnKeypressExtra(args);
+
+  return { args, onPauseSpy, onRepaintSpy, handler, exportStatus };
+}
+
+describe('makeOnKeypressExtra', () => {
+  const mShow = vi.mocked(showCombinedLogs);
+  const mWriteFailCsv = vi.mocked(writeFailingUpdatesCsv);
+
+  let writeSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Silence & capture stdout writes for assertions
+    writeSpy = vi
+      .spyOn(process.stdout, 'write')
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .mockImplementation(() => true as unknown as boolean) as any;
+  });
+
+  afterEach(() => {
+    writeSpy.mockRestore();
+  });
+
+  it('returns a keypress handler function', () => {
+    const { handler } = buildArgs();
+    expect(typeof handler).toBe('function');
+    // Explicit runtime check that it accepts a Buffer and returns void
+    const out: void = handler(Buffer.from('x'));
+    expect(out).toBeUndefined();
+  });
+
+  it('viewer keys call showCombinedLogs and pause the UI', () => {
+    const { handler, onPauseSpy } = buildArgs();
+
+    handler(Buffer.from('e')); // errors only
+    expect(mShow).toHaveBeenCalledWith(expect.anything(), ['err'], 'error');
+    expect(onPauseSpy).toHaveBeenLastCalledWith(true);
+
+    handler(Buffer.from('w')); // warn + err
+    expect(mShow).toHaveBeenCalledWith(
+      expect.anything(),
+      ['warn', 'err'],
+      'warn',
+    );
+
+    handler(Buffer.from('i')); // info
+    expect(mShow).toHaveBeenCalledWith(expect.anything(), ['info'], 'all');
+
+    handler(Buffer.from('l')); // all logs
+    expect(mShow).toHaveBeenCalledWith(
+      expect.anything(),
+      ['out', 'err', 'structured'],
+      'all',
+    );
+  });
+
+  it('export keys write combined logs, update exportStatus, and repaint', () => {
+    const { handler, exportStatus, onRepaintSpy } = buildArgs();
+
+    handler(Buffer.from('E'));
+    expect(writeSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Wrote combined error logs to: /exp/combined-error.log',
+      ),
+    );
+    expect(exportStatus.error?.path).toBe('/exp/combined-error.log');
+    expect(exportStatus.error?.exported).toBe(true);
+    expect(typeof exportStatus.error?.savedAt).toBe('number');
+    expect(onRepaintSpy).toHaveBeenCalled();
+
+    handler(Buffer.from('W'));
+    expect(writeSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Wrote combined warn logs to: /exp/combined-warn.log',
+      ),
+    );
+    expect(exportStatus.warn?.path).toBe('/exp/combined-warn.log');
+
+    handler(Buffer.from('I'));
+    expect(writeSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Wrote combined info logs to: /exp/combined-info.log',
+      ),
+    );
+    expect(exportStatus.info?.path).toBe('/exp/combined-info.log');
+
+    handler(Buffer.from('A'));
+    expect(writeSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Wrote combined ALL logs to: /exp/combined-all.log',
+      ),
+    );
+    expect(exportStatus.all?.path).toBe('/exp/combined-all.log');
+  });
+
+  it('handles export errors gracefully (writes failure message)', () => {
+    const { args, exportStatus } = buildArgs();
+    // Rebuild handler with a manager that throws on "warn"
+    const throwing = makeFakeExportManager({ throwForLevel: 'warn' });
+    const handler = makeOnKeypressExtra({ ...args, exportMgr: throwing });
+
+    handler(Buffer.from('W'));
+    expect(writeSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to write combined warn logs'),
+    );
+    // Should not set exportStatus.warn on failure
+    expect(exportStatus.warn).toBeUndefined();
+  });
+
+  it('writes failing updates CSV on "F" and records the path', () => {
+    const { handler, exportStatus, onRepaintSpy } = buildArgs();
+
+    handler(Buffer.from('F'));
+    expect(mWriteFailCsv).toHaveBeenCalledTimes(1);
+    expect(mWriteFailCsv.mock.calls[0]?.[1]).toBe('/exp/failing-updates.csv');
+
+    expect(writeSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Wrote failing updates CSV to: /exp/failing-updates.csv',
+      ),
+    );
+    expect(exportStatus.failuresCsv?.path).toBe('/exp/failing-updates.csv');
+    expect(exportStatus.failuresCsv?.exported).toBe(true);
+    expect(onRepaintSpy).toHaveBeenCalled();
+  });
+
+  it('handles failing updates CSV error path', () => {
+    const { args } = buildArgs();
+    mWriteFailCsv.mockImplementationOnce(() => {
+      throw Object.assign(new Error('nope'), { stack: 'STACK!' });
+    });
+    const handler = makeOnKeypressExtra(args);
+
+    handler(Buffer.from('F'));
+    expect(writeSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to write failing updates CSV'),
+    );
+    // includes stack
+    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining('STACK!'));
+  });
+
+  it('escape or ^] resumes (unpauses) and repaints', () => {
+    const { handler, onPauseSpy, onRepaintSpy } = buildArgs();
+    handler(Buffer.from('\x1b')); // ESC
+    expect(onPauseSpy).toHaveBeenCalledWith(false);
+    expect(onRepaintSpy).toHaveBeenCalled();
+
+    onPauseSpy.mockClear();
+    onRepaintSpy.mockClear();
+
+    handler(Buffer.from('\x1d')); // ^] (GS)
+    expect(onPauseSpy).toHaveBeenCalledWith(false);
+    expect(onRepaintSpy).toHaveBeenCalled();
+  });
+
+  it('unknown keys perform no actions', () => {
+    const { handler } = buildArgs();
+
+    handler(Buffer.from('z'));
+    expect(showCombinedLogs).not.toHaveBeenCalled();
+    expect(writeFailingUpdatesCsv).not.toHaveBeenCalled();
+    // No success/failure strings written
+    const allWrites = writeSpy.mock.calls.map((c) => String(c[0]));
+    const meaningful = allWrites.filter((s) => /Wrote|Failed/.test(s));
+    expect(meaningful.length).toBe(0);
+  });
+});

--- a/src/commands/consent/upload-preferences/ui/tests/renderDashboard.test.ts
+++ b/src/commands/consent/upload-preferences/ui/tests/renderDashboard.test.ts
@@ -1,0 +1,122 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+  beforeAll,
+} from 'vitest';
+import type { RenderDashboardInput } from '../buildFrameModel';
+
+const H = vi.hoisted(() => ({
+  cursorTo: vi.fn(),
+  clearScreenDown: vi.fn(),
+  writeIndex: vi.fn(),
+}));
+
+/* ---- Mocks must be registered before importing the SUT ---- */
+vi.mock('node:readline', () => ({
+  cursorTo: H.cursorTo,
+  clearScreenDown: H.clearScreenDown,
+}));
+
+vi.mock('../buildFrameModel', () => ({
+  buildFrameModel: vi.fn((input) => ({
+    input,
+    inProgress: 0,
+    pct: 0,
+    etaText: '',
+    estTotalJobs: undefined,
+  })),
+}));
+
+vi.mock('../headerLines', () => ({
+  headerLines: vi.fn(() => ['H1', 'H2']),
+  workerLines: vi.fn(() => ['W1', 'W2']),
+  hotkeysLine: vi.fn(() => 'HOT'),
+  exportBlock: vi.fn(() => 'EXP'),
+}));
+
+vi.mock('../../artifacts/writeExportsIndex', () => ({
+  writeExportsIndex: H.writeIndex,
+}));
+
+const expectedFrame = ['H1', 'H2', '', 'W1', 'W2', '', 'HOT', '', 'EXP'].join(
+  '\n',
+);
+
+describe('renderDashboard', () => {
+  let writeSpy: ReturnType<typeof vi.spyOn>;
+  let renderDashboard: (input: RenderDashboardInput) => void;
+
+  beforeAll(async () => {
+    // Ensure no previous module instance leaks
+    await vi.resetModules();
+    // Give the writeIndex stub a do-nothing return
+    H.writeIndex.mockReturnValue(undefined as unknown as string);
+    // Dynamically import SUT AFTER mocks are in place
+    ({ renderDashboard } = await import('../renderDashboard'));
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    writeSpy = vi
+      .spyOn(process.stdout, 'write')
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .mockImplementation(() => true) as any;
+  });
+
+  afterEach(() => {
+    writeSpy.mockRestore();
+  });
+
+  it('non-final render: writes exports index, hides cursor, clears screen, prints frame; skips redraw for identical frame', () => {
+    const input: RenderDashboardInput = {
+      poolSize: 2,
+      final: false,
+      exportsDir: '/exp',
+      exportStatus: {},
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    renderDashboard(input);
+
+    expect(H.writeIndex).toHaveBeenCalledWith('/exp', {});
+
+    expect(writeSpy).toHaveBeenCalledWith('\x1b[?25l');
+    expect(H.cursorTo).toHaveBeenCalledWith(process.stdout, 0, 0);
+    expect(H.clearScreenDown).toHaveBeenCalledWith(process.stdout);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const writes = writeSpy.mock.calls.map((c: any) => String(c[0]));
+    expect(writes).toContain(`${expectedFrame}\n`);
+
+    const beforeCalls = writeSpy.mock.calls.length;
+    renderDashboard(input);
+    expect(H.writeIndex).toHaveBeenCalledTimes(2);
+    expect(writeSpy.mock.calls.length).toBe(beforeCalls); // no additional writes
+  });
+
+  it('final render: writes exports index, shows cursor, prints frame, and does not move/clear the screen', () => {
+    const input = {
+      poolSize: 2,
+      final: true,
+      exportsDir: '/exp',
+      exportStatus: {},
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    renderDashboard(input);
+
+    expect(H.writeIndex).toHaveBeenCalledWith('/exp', {});
+
+    expect(writeSpy).toHaveBeenCalledWith('\x1b[?25h');
+    expect(H.cursorTo).not.toHaveBeenCalled();
+    expect(H.clearScreenDown).not.toHaveBeenCalled();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const writes = writeSpy.mock.calls.map((c: any) => String(c[0]));
+    expect(writes).toContain(`${expectedFrame}\n`);
+  });
+});

--- a/src/lib/helpers/RateCounter.ts
+++ b/src/lib/helpers/RateCounter.ts
@@ -1,0 +1,55 @@
+/**
+ * Tracks counts over time and calculates rates within a specified time window.
+ *
+ * This class maintains a rolling window of count "buckets" (timestamped values)
+ * and provides methods to add new counts and compute the rate of events over a
+ * configurable time window.
+ *
+ * Example usage:
+ * ```typescript
+ * const counter = new RateCounter();
+ * counter.add(5); // Add 5 events
+ * const rate = counter.rate(60_000); // Get rate over last 60 seconds
+ * ```
+ */
+export class RateCounter {
+  private buckets: Array<{
+    /** Timestamp of the bucket */
+    t: number;
+    /** Number of events in the bucket */
+    n: number;
+  }> = [];
+
+  /**
+   * Adds a new count to the counter.
+   *
+   * @param n - The number of events to add to the counter.
+   */
+  add(n: number): void {
+    const now = Date.now();
+    this.buckets.push({ t: now, n });
+    // keep last 2 minutes of buckets
+    const cutoff = now - 120_000;
+    while (this.buckets.length && this.buckets[0].t < cutoff) {
+      this.buckets.shift();
+    }
+  }
+
+  /**
+   * rate over the last `windowMs` milliseconds
+   *
+   * @param windowMs - The time window in milliseconds to calculate the rate over.
+   * @returns The average rate of events per second over the specified time window.
+   */
+  rate(windowMs: number): number {
+    const now = Date.now();
+    const cutoff = now - windowMs;
+    let sum = 0;
+    for (let i = this.buckets.length - 1; i >= 0; i -= 1) {
+      const b = this.buckets[i];
+      if (b.t < cutoff) break;
+      sum += b.n;
+    }
+    return sum / (windowMs / 1000);
+  }
+}

--- a/src/lib/helpers/index.ts
+++ b/src/lib/helpers/index.ts
@@ -8,3 +8,5 @@ export * from './sleepPromise';
 export * from './splitInHalf';
 export * from './retrySamePromise';
 export * from './limitRecords';
+export * from './RateCounter';
+export * from './readSafe';

--- a/src/lib/helpers/readSafe.ts
+++ b/src/lib/helpers/readSafe.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from 'node:fs';
+
+/**
+ * Safely reads the contents of a file as a UTF-8 string.
+ * Returns an empty string if the path is not provided or if reading fails.
+ *
+ * @param p - The path to the file to read.
+ * @returns The file contents as a string, or an empty string on error.
+ */
+export function readSafe(p?: string): string {
+  try {
+    return p ? readFileSync(p, 'utf8') : '';
+  } catch {
+    return '';
+  }
+}

--- a/src/lib/helpers/tests/RateCounter.test.ts
+++ b/src/lib/helpers/tests/RateCounter.test.ts
@@ -1,4 +1,3 @@
-// src/lib/pooling/tests/RateCounter.test.ts
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { RateCounter } from '../RateCounter';
 

--- a/src/lib/helpers/tests/RateCounter.test.ts
+++ b/src/lib/helpers/tests/RateCounter.test.ts
@@ -1,0 +1,95 @@
+// src/lib/pooling/tests/RateCounter.test.ts
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { RateCounter } from '../RateCounter';
+
+describe('RateCounter', () => {
+  const T0 = 1_700_000_000_000; // fixed epoch for deterministic Date.now()
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(T0);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  /**
+   * Sanity: empty counter yields zero rate for any window.
+   */
+  it('returns 0 rate when no buckets exist', () => {
+    const rc = new RateCounter();
+    expect(rc.rate(60_000)).toBe(0);
+    expect(rc.rate(10_000)).toBe(0);
+    expect(rc.rate(120_000)).toBe(0);
+  });
+
+  /**
+   * Adds three buckets at T0, T0+30s, T0+70s and queries rate over the last 60s
+   * at T0+70s. The first bucket is outside the 60s window, so only the latter
+   * two are included.
+   *
+   * Sum = 20 + 30 = 50; Window = 60s → 50/60 ≈ 0.8333
+   */
+  it('computes rate over a window including only recent buckets', () => {
+    const rc = new RateCounter();
+
+    // at T0
+    vi.setSystemTime(T0);
+    rc.add(10);
+
+    // at T0 + 30s
+    vi.setSystemTime(T0 + 30_000);
+    rc.add(20);
+
+    // at T0 + 70s
+    vi.setSystemTime(T0 + 70_000);
+    rc.add(30);
+
+    // rate over last 60s at now = T0 + 70s → includes +30s and +70s buckets
+    const r = rc.rate(60_000);
+    expect(r).toBeCloseTo(50 / 60, 6);
+  });
+
+  /**
+   * Boundary behavior: a bucket exactly at the cutoff time (now - windowMs)
+   * should be included (code excludes only when b.t < cutoff).
+   *
+   * At T0 add 10, then at T0+60s compute a 60s window → includes the T0 bucket.
+   * Rate = 10 / 60.
+   */
+  it('includes a bucket exactly at the cutoff boundary', () => {
+    const rc = new RateCounter();
+
+    vi.setSystemTime(T0);
+    rc.add(10);
+
+    vi.setSystemTime(T0 + 60_000);
+    const r = rc.rate(60_000);
+    expect(r).toBeCloseTo(10 / 60, 6);
+  });
+
+  /**
+   * Pruning behavior: add a bucket, move time forward > 120s, then add another
+   * bucket. The first bucket should be pruned during the second `.add()`.
+   *
+   * We then compute rate over a large window (10 minutes) so that if pruning
+   * did NOT happen, the old bucket would have been counted. Expected sum is
+   * only the second bucket.
+   */
+  it('prunes buckets older than 120s on add()', () => {
+    const rc = new RateCounter();
+
+    // First bucket at T0
+    vi.setSystemTime(T0);
+    rc.add(100);
+
+    // Advance past 120s window, second add triggers pruning of the first
+    vi.setSystemTime(T0 + 150_000);
+    rc.add(50);
+
+    // Large window (600s): if pruning failed, sum would be 150; correct sum = 50
+    const r = rc.rate(600_000);
+    expect(r).toBeCloseTo(50 / 600, 6);
+  });
+});

--- a/src/lib/helpers/tests/readSafe.test.ts
+++ b/src/lib/helpers/tests/readSafe.test.ts
@@ -1,0 +1,66 @@
+// src/lib/pooling/tests/readSafe.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { readFileSync } from 'node:fs';
+import { readSafe } from '../readSafe';
+
+/**
+ * Mock fs BEFORE importing the SUT.
+ * Use a factory so the mock is hoist-safe under Vitest.
+ */
+vi.mock('node:fs', () => ({
+  readFileSync: vi.fn(),
+}));
+
+describe('readSafe', () => {
+  const mRead = vi.mocked(readFileSync);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  /**
+   * When path is undefined, it should return an empty string
+   * and not call fs at all.
+   */
+  it('returns empty string when path is undefined', () => {
+    const out = readSafe(undefined);
+    expect(out).toBe('');
+    expect(mRead).not.toHaveBeenCalled();
+  });
+
+  /**
+   * When given a valid path, it returns the file contents
+   * and calls fs.readFileSync with 'utf8' encoding.
+   */
+  it('reads and returns file contents with utf8', () => {
+    mRead.mockReturnValue('hello world');
+    const out = readSafe('/tmp/test.txt');
+    expect(out).toBe('hello world');
+    expect(mRead).toHaveBeenCalledTimes(1);
+    expect(mRead).toHaveBeenCalledWith('/tmp/test.txt', 'utf8');
+  });
+
+  /**
+   * If fs.readFileSync throws, the function should swallow the error
+   * and return an empty string.
+   */
+  it('returns empty string when readFileSync throws', () => {
+    mRead.mockImplementation(() => {
+      throw new Error('boom');
+    });
+    const out = readSafe('/tmp/missing.txt');
+    expect(out).toBe('');
+    expect(mRead).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * Empty string path is treated as "no path" (falsy) and returns empty,
+   * without calling fs.
+   */
+  it('returns empty string when path is an empty string', () => {
+    const out = readSafe('');
+    expect(out).toBe('');
+    expect(mRead).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/helpers/tests/readSafe.test.ts
+++ b/src/lib/helpers/tests/readSafe.test.ts
@@ -1,4 +1,3 @@
-// src/lib/pooling/tests/readSafe.test.ts
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import { readFileSync } from 'node:fs';

--- a/src/lib/helpers/tests/retrySamePromise.test.ts
+++ b/src/lib/helpers/tests/retrySamePromise.test.ts
@@ -1,4 +1,3 @@
-// src/lib/helpers/tests/retrySamePromise.test.ts
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import { retrySamePromise, type RetryPolicy } from '../retrySamePromise';

--- a/src/lib/pooling/tests/wireStderrBadges.test.ts
+++ b/src/lib/pooling/tests/wireStderrBadges.test.ts
@@ -1,4 +1,3 @@
-// src/lib/pooling/tests/diagnostics.wireStderrBadges.test.ts
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { ChildProcess } from 'node:child_process';
 import { EventEmitter } from 'node:events';

--- a/src/lib/tests/codebase.test.ts
+++ b/src/lib/tests/codebase.test.ts
@@ -234,21 +234,61 @@ describe('CLI Command Structure', () => {
   });
 
   describe('Folder structure integrity', () => {
-    test('No extra files in command directories', () => {
-      // For each command, ensure only command.ts, impl.ts, and optionally readme.ts exist
+    test('No unexpected files in command directories', () => {
+      // Required + optional files in leaf command dirs
+      const requiredFiles = ['command.ts', 'impl.ts'];
+      const optionalFiles = [
+        'readme.ts',
+        'helpers.ts',
+        'types.ts',
+        'constants.ts',
+      ];
+
+      // Allowed subdirectories in leaf command dirs
+      const allowedDirs = [
+        'artifacts',
+        'ui',
+        'tests',
+        '__mocks__',
+        '__snapshots__',
+      ];
+
       for (const command of allCommands) {
         const commandPath = path.join('src', 'commands', ...command);
-        const files = fs
-          .readdirSync(commandPath)
-          .filter((file) => file !== '.DS_Store');
 
-        // Allow command.ts, impl.ts, and optionally readme.ts
-        const allowedFiles = ['command.ts', 'impl.ts'];
-        if (files.includes('readme.ts')) {
-          allowedFiles.push('readme.ts');
+        const entries = fs
+          .readdirSync(commandPath, { withFileTypes: true })
+          .filter((e) => e.name !== '.DS_Store');
+
+        const fileNames = entries.filter((e) => e.isFile()).map((e) => e.name);
+        const dirNames = entries
+          .filter((e) => e.isDirectory())
+          .map((e) => e.name);
+
+        // 1) Required files must exist
+        for (const req of requiredFiles) {
+          expect(
+            fileNames.includes(req),
+            `${commandPath} is missing required file: ${req}`,
+          ).toBe(true);
         }
 
-        expect(files.sort()).toEqual(allowedFiles.sort());
+        // 2) No unexpected files
+        const allowedFiles = new Set([...requiredFiles, ...optionalFiles]);
+        const unexpectedFiles = fileNames.filter((f) => !allowedFiles.has(f));
+        expect(
+          unexpectedFiles,
+          `${commandPath} has unexpected files: ${unexpectedFiles.join(', ')}`,
+        ).toEqual([]);
+
+        // 3) No unexpected directories
+        const unexpectedDirs = dirNames.filter((d) => !allowedDirs.includes(d));
+        expect(
+          unexpectedDirs,
+          `${commandPath} has unexpected directories: ${unexpectedDirs.join(
+            ', ',
+          )}`,
+        ).toEqual([]);
       }
     });
 


### PR DESCRIPTION
- ref https://linear.app/transcend/issue/PIK-166/fix-prferences-cli-to-handle-mutliple-identifiers
- picked from https://github.com/transcend-io/cli/pull/444

## Artifacts

This pull request introduces a new export artifact management system for consent upload-preferences, focusing on providing a unified API for artifact paths, exporting, and index writing. It adds the core logic, public API, and comprehensive tests for artifact path resolution, artifact export operations, and index/CSV writing. The changes are grouped into three main themes: artifact management logic, artifact path resolution, and testing.

**Artifact Management Logic:**

* Added the `ExportManager` class in `ExportManager.ts`, which provides methods to resolve artifact paths, open/reveal/copy artifacts, and export combined logs by type. This class centralizes all artifact-related operations for exports.
* Implemented `writeExportsIndex` to generate a human-readable index file listing all export artifact paths and URLs, with memoization to avoid unnecessary writes.
* Implemented `writeFailingUpdatesCsv` to write failing update rows to a CSV file, supporting union headers and proper escaping.

**Artifact Path Resolution:**

* Added `artifactAbsPath` in `artifactAbsPath.ts`, which resolves the absolute path for any export artifact kind, supporting custom status, fallbacks, and placeholder handling. Also defined types for artifact status and artifact kind.

**Testing and Public API:**

* Created a public API entry point in `index.ts` to export all artifact management utilities.
* Added comprehensive unit tests for all new modules: `ExportManager.test.ts` [[1]](diffhunk://#diff-2a7123544cd2fe56135d7008f626b9bd9a5a3b725d54614eec2e3bb204543995R1-R173) [[2]](diffhunk://#diff-de0d9d37f7da574070a3d8ae086d0bcf35f12d777f1f1f88c27b00c9c099964aR1-R138) `artifactAbsPath.test.ts` [[3]](diffhunk://#diff-8114a0321029c636af47427e40467b8dd1e6a7adbdd55d278a5866f09f1ff449R1-R66) `writeExportsIndex.test.ts` [[4]](diffhunk://#diff-3d78c77e44828f2533422d549a4fc26fcf63a07a6d63fc351e0c21de4b6cdd43R1-R124) and `writeFailingUpdatesCsv.test.ts` [[5]](diffhunk://#diff-a4a7b2d23a8ecd53e4ea209df0700ec66b953030341440e73d959113c915693fR1-R101)

These changes collectively provide a robust and testable foundation for managing export artifacts, their paths, and related operations in the consent upload-preferences workflow.## Related Issues


## UI

Additionally - this pull request defines some functions that can be used to generate an interactive terminal session. It renders a dashboard that allows for
- viewing overall scan progress
- viewing active progress for each parallel scan run
- exporting artifacts like logs and failing requests
- switching between processes to see current log threads
- estimating progress to completion 


<img width="1104" height="313" alt="Screenshot 2025-08-17 at 4 25 32 PM" src="https://github.com/user-attachments/assets/4c03254d-9181-4c0c-843c-eb2871146f3d" />
