### PR TITLE
Fix "IS_NOT_SHOWN" display logic in assessment template pulls

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/cli",
   "description": "A command line interface for programmatic operations across Transcend.",
-  "version": "8.1.2",
+  "version": "8.1.3",
   "homepage": "https://github.com/transcend-io/cli",
   "repository": {
     "type": "git",

--- a/src/lib/graphql/parseAssessmentDisplayLogic.ts
+++ b/src/lib/graphql/parseAssessmentDisplayLogic.ts
@@ -6,12 +6,33 @@ import {
 import { decodeCodec, valuesOf } from '@transcend-io/type-utils';
 import * as t from 'io-ts';
 
-export const AssessmentRule = t.type({
+// This codec is for rules that logically require a list of values to compare against.
+export const AssessmentRuleWithOperands = t.type({
   dependsOnQuestionReferenceId: t.string,
-  comparisonOperator: valuesOf(ComparisonOperator),
+  comparisonOperator: t.union([
+    t.literal(ComparisonOperator.IsEqualTo),
+    t.literal(ComparisonOperator.IsNotEqualTo),
+    t.literal(ComparisonOperator.IsOneOf),
+    t.literal(ComparisonOperator.IsNotOneOf),
+    t.literal(ComparisonOperator.Contains),
+    t.literal(ComparisonOperator.IsShown),
+  ]),
   comparisonOperands: t.array(t.string),
 });
 
+// This codec is for the specific rule that does NOT require comparison operands.
+export const AssessmentRuleWithoutOperands = t.type({
+  dependsOnQuestionReferenceId: t.string,
+  comparisonOperator: t.literal(ComparisonOperator.IsNotShown),
+});
+
+/**
+ * The final, flexible codec that accepts EITHER a rule with operands OR a rule without them.
+ */
+export const AssessmentRule = t.union([
+  AssessmentRuleWithOperands,
+  AssessmentRuleWithoutOperands,
+]);
 /** Type override */
 export type AssessmentRule = t.TypeOf<typeof AssessmentRule>;
 

--- a/src/lib/graphql/pullTranscendConfiguration.ts
+++ b/src/lib/graphql/pullTranscendConfiguration.ts
@@ -88,8 +88,8 @@ import { fetchPartitions } from './syncPartitions';
 import { fetchAllAssessments } from './fetchAllAssessments';
 import { fetchAllAssessmentTemplates } from './fetchAllAssessmentTemplates';
 import {
-  AssessmentNestedRule,
   parseAssessmentDisplayLogic,
+  type AssessmentRule,
 } from './parseAssessmentDisplayLogic';
 import { parseAssessmentRiskLogic } from './parseAssessmentRiskLogic';
 import { fetchAllPurposesAndPreferences } from './fetchAllPurposesAndPreferences';
@@ -530,29 +530,30 @@ export async function pullTranscendConfiguration(
                                 'comparison-operator':
                                   displayLogicParsed.rule.comparisonOperator,
                                 'comparison-operands':
-                                  displayLogicParsed.rule.comparisonOperands,
+                                  // Safely access property with a check
+                                  'comparisonOperands' in
+                                  displayLogicParsed.rule
+                                    ? displayLogicParsed.rule.comparisonOperands
+                                    : undefined,
                               }
                             : undefined,
                           'nested-rule': displayLogicParsed.nestedRule
                             ? {
                                 'logic-operator':
                                   displayLogicParsed.nestedRule.logicOperator,
-                                rules:
-                                  /* eslint-disable @typescript-eslint/no-explicit-any */
-                                  (
-                                    (
-                                      (displayLogicParsed as any)
-                                        .nestedRule as AssessmentNestedRule
-                                    ).rules || []
-                                  ).map((rule) => ({
-                                    'depends-on-question-reference-id':
-                                      rule.dependsOnQuestionReferenceId,
-                                    'comparison-operator':
-                                      rule.comparisonOperator,
-                                    'comparison-operands':
-                                      rule.comparisonOperands,
-                                  })),
-                                /* eslint-enable @typescript-eslint/no-explicit-any */
+                                rules: (
+                                  displayLogicParsed.nestedRule.rules || []
+                                ).map((rule: AssessmentRule) => ({
+                                  'depends-on-question-reference-id':
+                                    rule.dependsOnQuestionReferenceId,
+                                  'comparison-operator':
+                                    rule.comparisonOperator,
+                                  'comparison-operands':
+                                    // Safely access property on the nested rule
+                                    'comparisonOperands' in rule
+                                      ? rule.comparisonOperands
+                                      : undefined,
+                                })),
                               }
                             : undefined,
                         }
@@ -706,29 +707,30 @@ export async function pullTranscendConfiguration(
                                 'comparison-operator':
                                   displayLogicParsed.rule.comparisonOperator,
                                 'comparison-operands':
-                                  displayLogicParsed.rule.comparisonOperands,
+                                  // Safely access property with a check
+                                  'comparisonOperands' in
+                                  displayLogicParsed.rule
+                                    ? displayLogicParsed.rule.comparisonOperands
+                                    : undefined,
                               }
                             : undefined,
                           'nested-rule': displayLogicParsed.nestedRule
                             ? {
                                 'logic-operator':
                                   displayLogicParsed.nestedRule.logicOperator,
-                                rules:
-                                  /* eslint-disable @typescript-eslint/no-explicit-any */
-                                  (
-                                    (
-                                      (displayLogicParsed as any)
-                                        .nestedRule as AssessmentNestedRule
-                                    ).rules || []
-                                  ).map((rule) => ({
-                                    'depends-on-question-reference-id':
-                                      rule.dependsOnQuestionReferenceId,
-                                    'comparison-operator':
-                                      rule.comparisonOperator,
-                                    'comparison-operands':
-                                      rule.comparisonOperands,
-                                  })),
-                                /* eslint-enable @typescript-eslint/no-explicit-any */
+                                rules: (
+                                  displayLogicParsed.nestedRule.rules || []
+                                ).map((rule: AssessmentRule) => ({
+                                  'depends-on-question-reference-id':
+                                    rule.dependsOnQuestionReferenceId,
+                                  'comparison-operator':
+                                    rule.comparisonOperator,
+                                  'comparison-operands':
+                                    // Safely access property on the nested rule
+                                    'comparisonOperands' in rule
+                                      ? rule.comparisonOperands
+                                      : undefined,
+                                })),
                               }
                             : undefined,
                         }


### PR DESCRIPTION
Comparison Operator for "IsNotShown" was breaking display logic rules. pulls of assessment templates with this display logic would fail